### PR TITLE
Add varnish images for CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,4 +5,14 @@ Pull command:
  * `docker pull datadog/docker-library`
 
 Currently available tags:
- * [`elasticsearch_0_90`](https://github.com/DataDog/docker-library/blob/bb1f2547e59c779014e1034aedc451e2c47cc8cb/elasticsearch/0.90/Dockerfile): Elasticsearch v.0.90.13
+ * [`elasticsearch_1_2`](https://github.com/DataDog/docker-library/tree/master/elasticsearch/1.2): Elasticsearch v.1.2
+ * [`elasticsearch_1_1`](https://github.com/DataDog/docker-library/tree/master/elasticsearch/1.1): Elasticsearch v.1.1
+ * [`elasticsearch_1_0`](https://github.com/DataDog/docker-library/tree/master/elasticsearch/1.0): Elasticsearch v.1.0
+ * [`elasticsearch_0_90`](https://github.com/DataDog/docker-library/tree/master/elasticsearch/0.90): Elasticsearch v.0.90.13
+ * [`powerdns_recursor_4_0_3`](https://github.com/DataDog/docker-library/tree/master/powerdns\_recursor/4.0.3): Powerdns Recursor v.4.0.3
+ * [`powerdns_recursor_4_0_0`](https://github.com/DataDog/docker-library/tree/master/powerdns\_recursor/4.0.0): Powerdns Recursor v.4.0.0
+ * [`powerdns_recursor_3_7_3`](https://github.com/DataDog/docker-library/tree/master/powerdns\_recursor/3.7.3): Powerdns Recursor v.3.7.3
+ * [`supervisord_3_3_0`](https://github.com/DataDog/docker-library/tree/master/supervisord/3.3.0): Supervisord v.3.3.0
+ * [`kyototycoon_0_9_56`](https://github.com/DataDog/docker-library/tree/master/kyototycoon/0.9.56): Kyototycoon v.0.9.56
+ * [`varnish_5_0_0`](https://github.com/DataDog/docker-library/tree/master/varnish/5.0.0): Varnish v.5.0.0
+ * [`varnish_4_1_4`](https://github.com/DataDog/docker-library/tree/master/varnish/4.1.4): Varnish v.4.1.4

--- a/varnish/4.1.4/Dockerfile
+++ b/varnish/4.1.4/Dockerfile
@@ -1,0 +1,17 @@
+from debian:jessie
+
+RUN apt-get update -y \
+    && apt-get install -y \
+    apt-transport-https \
+    curl
+
+ADD varnish_4.1.4.pref /etc/apt/preferences.d/
+RUN curl https://repo.varnish-cache.org/GPG-key.txt | apt-key add -
+RUN echo "deb https://repo.varnish-cache.org/debian/ jessie varnish-4.1"  | tee -a /etc/apt/sources.list.d/varnish-cache.list
+RUN apt-get update \
+    && apt-get install -y varnish \
+    && apt-get clean all
+
+EXPOSE 80
+
+CMD ["varnishd", "-F", "-f", "/etc/varnish/default.vcl"]

--- a/varnish/4.1.4/varnish_4.1.4.pref
+++ b/varnish/4.1.4/varnish_4.1.4.pref
@@ -1,0 +1,3 @@
+Package: varnish
+Pin: version 4.1.4-*
+Pin-Priority: 1001

--- a/varnish/5.0.0/Dockerfile
+++ b/varnish/5.0.0/Dockerfile
@@ -1,0 +1,12 @@
+from debian:stretch
+
+ADD varnish_5.0.0.pref /etc/apt/preferences.d/
+RUN apt-get update -y \
+    && apt-get install -y apt-transport-https \
+    && apt-get install -y \
+        varnish \
+    && apt-get clean all
+
+EXPOSE 80
+
+CMD ["varnishd", "-F", "-f", "/etc/varnish/default.vcl"]

--- a/varnish/5.0.0/varnish_5.0.0.pref
+++ b/varnish/5.0.0/varnish_5.0.0.pref
@@ -1,0 +1,3 @@
+Package: varnish
+Pin: version 5.0.0-*
+Pin-Priority: 1001


### PR DESCRIPTION
Varnish 4.1.4 and 5.0.0 are added based on debian. The main purpose it to be used by the CI for varnish integration.