### PR TITLE
[dotnet] add dotnet container with Mono

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,4 @@ Currently available tags:
  * [`kyototycoon_0_9_56`](https://github.com/DataDog/docker-library/tree/master/kyototycoon/0.9.56): Kyototycoon v.0.9.56
  * [`varnish_5_0_0`](https://github.com/DataDog/docker-library/tree/master/varnish/5.0.0): Varnish v.5.0.0
  * [`varnish_4_1_7`](https://github.com/DataDog/docker-library/tree/master/varnish/4.1.7): Varnish v.4.1.7
+ * [`ddtrace_csharp_0_1_0`](https://github.com/DataDog/docker-library/tree/master/dd-trace-csharp/0.1.0): C# test runner v.0.1.0

--- a/dd-trace-csharp/0.1.0/Dockerfile
+++ b/dd-trace-csharp/0.1.0/Dockerfile
@@ -1,0 +1,9 @@
+FROM microsoft/dotnet:latest
+
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF \
+ && echo "deb http://download.mono-project.com/repo/debian stretch main" >> /etc/apt/sources.list.d/mono-official.list \
+ && apt-get update \
+ && apt-get install -y --no-install-recommends mono-devel msbuild libuv1-dev \
+ && rm -rf /var/lib/apt/lists/*
+
+ENV FrameworkPathOverride="/usr/lib/mono/4.5/"


### PR DESCRIPTION
### Overview

Add a container to provide a test runner for `dd-trace-csharp`.