### PR TITLE
[cpp] Add C++ OpenTracing CI build base image

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Currently available tags:
 * [`kyototycoon_0_9_56`](https://github.com/DataDog/docker-library/tree/master/kyototycoon/0.9.56): Kyototycoon v.0.9.56
 * [`varnish_5_0_0`](https://github.com/DataDog/docker-library/tree/master/varnish/5.0.0): Varnish v.5.0.0
 * [`varnish_4_1_7`](https://github.com/DataDog/docker-library/tree/master/varnish/4.1.7): Varnish v.4.1.7
+* [`dd-opentracing-cpp_0_1_0`](https://github.com/DataDog/docker-library/tree/master/dd-opentracing-cpp/0.1.0): Base image for CircleCI build of C++ OpenTracing integration
 * [`ddtrace_csharp_0_1_0`](https://github.com/DataDog/docker-library/tree/master/dd-trace-csharp/0.1.0): C# test runner v.0.1.0
 * [`ddtrace_rb_1_9_3`](https://github.com/DataDog/docker-library/tree/master/dd-trace-rb/1.9.3): Test runner for Ruby version 1.9.3
 * [`ddtrace_rb_2_0_0`](https://github.com/DataDog/docker-library/tree/master/dd-trace-rb/2.0.0): Test runner for Ruby version 2.0.0

--- a/dd-opentracing-cpp/0.1.0/Dockerfile
+++ b/dd-opentracing-cpp/0.1.0/Dockerfile
@@ -1,0 +1,17 @@
+FROM ubuntu:latest
+
+RUN apt-get update && \
+    apt-get install -y \
+    # Basic circleci utils
+    ca-certificates git curl wget tar sudo \
+    # Source tools
+    clang-format-5.0 \
+    # Build tools
+    build-essential cmake \
+    # Build dependencies
+    libpcre3-dev zlib1g-dev libcurl4-openssl-dev libssl-dev \
+    # Nginx build dependencies
+    libxml2-dev libxslt-dev libgd-dev libgeoip-dev \
+    # Packaging tools
+    ruby ruby-dev lsb-release
+

--- a/dd-opentracing-cpp/0.1.0/Dockerfile
+++ b/dd-opentracing-cpp/0.1.0/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:latest
+FROM ubuntu:18.04
 
 RUN apt-get update && \
     apt-get install -y \


### PR DESCRIPTION
Adds a base image to use for CI builds of dd-opentracing-cpp.

Builds: https://circleci.com/gh/DataDog/dd-opentracing-cpp/183
Repo: https://github.com/DataDog/dd-opentracing-cpp
