### PR TITLE
Adds clang-format-6.0 to csharp CI image

### DIFF
--- a/dd-trace-csharp/0.1.1/Dockerfile
+++ b/dd-trace-csharp/0.1.1/Dockerfile
@@ -2,8 +2,10 @@ FROM microsoft/dotnet:latest
 
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF \
  && echo "deb http://download.mono-project.com/repo/debian stretch main" >> /etc/apt/sources.list.d/mono-official.list \
+ && wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - \
+ && echo "deb http://apt.llvm.org/stretch/ llvm-toolchain-stretch-6.0 main" >> /etc/apt/sources.list \
  && apt-get update \
- && apt-get install -y --no-install-recommends mono-devel msbuild libuv1-dev \
+ && apt-get install -y --no-install-recommends mono-devel msbuild libuv1-dev clang-format-6.0 \
  && rm -rf /var/lib/apt/lists/*
 
 ENV FrameworkPathOverride="/usr/lib/mono/4.5/"


### PR DESCRIPTION
Sister PR: https://github.com/DataDog/dd-trace-csharp/pull/86