### PR TITLE
Adds prereqs for building nginx

### DIFF
--- a/dd-opentracing-cpp/build/0.3.1/Dockerfile
+++ b/dd-opentracing-cpp/build/0.3.1/Dockerfile
@@ -7,5 +7,7 @@ RUN apt-get update && \
   # Source tools
   clang-format-5.0 \
   # Build tools
-  build-essential cmake
+  build-essential cmake \
+  # Nginx requirements
+  libpcre3-dev zlib1g-dev
 


### PR DESCRIPTION
Required so we can build nginx-opentracing ourselves, so we can upgrade to the new OpenTracing dynamic loading version without CI breaking and before any nginx-opentracing release supports it.