### PR TITLE
Add snmp image

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,4 @@ Currently available tags:
 * [`nginx-vts`](https://github.com/DataDog/docker-library/tree/master/nginx-vts)
 * [`pgbouncer_1_7`](https://github.com/DataDog/docker-library/tree/master/pgbouncer/1.7)
 * [`pgbouncer_1_8`](https://github.com/DataDog/docker-library/tree/master/pgbouncer/1.7)
+* [`snmp`](https://github.com/DataDog/docker-library/tree/master/snmp): Image for SNMP testing with [snmpsim](http://snmplabs.com/snmpsim/quickstart.html)

--- a/snmp/Dockerfile
+++ b/snmp/Dockerfile
@@ -1,0 +1,14 @@
+FROM debian:stable-slim
+
+RUN apt-get update \
+    && apt-get install -y curl python gpg procps \
+    && apt-get clean
+RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py \
+    && python get-pip.py \
+    && rm get-pip.py
+RUN pip install snmpsim
+RUN groupadd snmpsim && useradd snmpsim -g snmpsim
+
+VOLUME /usr/snmpsim/data
+
+ENTRYPOINT ["snmpsimd.py", "--agent-udpv4-endpoint=0.0.0.0:1161", "--process-user=snmpsim", "--process-group=snmpsim"]


### PR DESCRIPTION
Add an image for a container running [`smnpsim`](http://snmplabs.com/snmpsim/quickstart.html) to allow for more flexible testing of the SNMP check.