### PR TITLE
Add python tracer test runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Currently available tags:
 * [`ddtrace_rb_2_2_10`](https://github.com/DataDog/docker-library/tree/master/dd-trace-rb/2.2.10): Test runner for Ruby version 2.2.10
 * [`ddtrace_rb_2_3_7`](https://github.com/DataDog/docker-library/tree/master/dd-trace-rb/2.3.7): Test runner for Ruby version 2.3.7
 * [`ddtrace_rb_2_4_4`](https://github.com/DataDog/docker-library/tree/master/dd-trace-rb/2.4.4): Test runner for Ruby version 2.4.4
-* [`ddtrace_py`](https://github.com/DataDog/docker-library/tree/master/dd-trace-pi): Test runner for Python
+* [`ddtrace_py`](https://github.com/DataDog/docker-library/tree/master/dd-trace-py): Test runner for Python
 * [`memcached_SASL`](https://github.com/DataDog/docker-library/tree/master/memcached)
 * [`nginx-vts`](https://github.com/DataDog/docker-library/tree/master/nginx-vts)
 * [`pgbouncer_1_7`](https://github.com/DataDog/docker-library/tree/master/pgbouncer/1.7)

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Currently available tags:
 * [`ddtrace_rb_2_2_10`](https://github.com/DataDog/docker-library/tree/master/dd-trace-rb/2.2.10): Test runner for Ruby version 2.2.10
 * [`ddtrace_rb_2_3_7`](https://github.com/DataDog/docker-library/tree/master/dd-trace-rb/2.3.7): Test runner for Ruby version 2.3.7
 * [`ddtrace_rb_2_4_4`](https://github.com/DataDog/docker-library/tree/master/dd-trace-rb/2.4.4): Test runner for Ruby version 2.4.4
+* [`ddtrace_py`](https://github.com/DataDog/docker-library/tree/master/dd-trace-pi): Test runner for Python
 * [`memcached_SASL`](https://github.com/DataDog/docker-library/tree/master/memcached)
 * [`nginx-vts`](https://github.com/DataDog/docker-library/tree/master/nginx-vts)
 * [`pgbouncer_1_7`](https://github.com/DataDog/docker-library/tree/master/pgbouncer/1.7)

--- a/dd-trace-py/Dockerfile
+++ b/dd-trace-py/Dockerfile
@@ -1,0 +1,45 @@
+# Latest image for this Dockerfile: datadog/docker-library:ddtrace_py
+FROM alpine:3.4
+
+RUN apk add --no-cache --update \
+            python \
+            bash \
+            build-base \
+            bzip2-dev \
+            ca-certificates \
+            curl \
+            cyrus-sasl-dev \
+            git \
+            jq \
+            libffi-dev \
+            libmemcached-dev \
+            linux-headers \
+            mariadb-dev \
+            memcached-dev \
+            ncurses-dev \
+            openssl \
+            openssl-dev \
+            patch \
+            postgresql-dev=9.5.13-r0 \
+            readline-dev \
+            sqlite-dev \
+            zlib-dev
+
+
+# Install pyenv
+RUN curl -L https://raw.githubusercontent.com/pyenv/pyenv-installer/master/bin/pyenv-installer | sh
+ENV PATH /root/.pyenv/shims:/root/.pyenv/bin:$PATH
+
+# Install all required python versions
+RUN pyenv install 2.7.12
+RUN pyenv install 3.4.4
+RUN pyenv install 3.5.2
+RUN pyenv install 3.6.1
+RUN pyenv global 2.7.12 3.4.4 3.5.2 3.6.1
+RUN pip install --upgrade pip
+
+# Install tox
+RUN pip install "tox>=3.3,<4.0"
+
+# Cleaning up apk cache space
+RUN rm -rf /var/cache/apk/*


### PR DESCRIPTION
We add the python tracer test runner to the docker library as we do for other integrations.
Previously, we had an image defined into a `Dockerfile` in our repo but for consistency with other integrations we prefer to have it defined here in our docker library repo.

The main objective of this PR is:
 - move the file https://github.com/DataDog/dd-trace-py/blob/168135cdb60ae892addd7b09b30fc71fba772b3a/.circleci/images/runner/Dockerfile to this repo
 - move from an ubuntu based image to an alpine based image to save some space

Please note that a build setting has already been added to https://hub.docker.com/r/datadog/docker-library/~/settings/automated-builds/
