### PR TITLE
[dd-trace-py] Update test docker image

### DIFF
--- a/dd-trace-py/Dockerfile
+++ b/dd-trace-py/Dockerfile
@@ -1,45 +1,48 @@
-# Latest image for this Dockerfile: datadog/docker-library:ddtrace_py
+  # Latest image for this Dockerfile: datadog/docker-library:ddtrace_py
 FROM alpine:3.4
 
-RUN apk add --no-cache --update \
-            python \
-            bash \
-            build-base \
-            bzip2-dev \
-            ca-certificates \
-            curl \
-            cyrus-sasl-dev \
-            git \
-            jq \
-            libffi-dev \
-            libmemcached-dev \
-            linux-headers \
-            mariadb-dev \
-            memcached-dev \
-            ncurses-dev \
-            openssl \
-            openssl-dev \
-            patch \
-            postgresql-dev=9.5.13-r0 \
-            readline-dev \
-            sqlite-dev \
-            zlib-dev
-
+RUN \
+  # Install system dependencies
+  apk add --no-cache --update \
+      python \
+      bash \
+      build-base \
+      bzip2-dev \
+      ca-certificates \
+      curl \
+      cyrus-sasl-dev \
+      git \
+      jq \
+      libffi-dev \
+      libmemcached-dev \
+      linux-headers \
+      mariadb-dev \
+      memcached-dev \
+      ncurses-dev \
+      openssl \
+      openssl-dev \
+      patch \
+      postgresql-dev=9.5.13-r0 \
+      readline-dev \
+      sqlite-dev \
+      zlib-dev \
+  # Cleaning up apk cache space
+  && rm -rf /var/cache/apk/*
 
 # Install pyenv
 RUN curl -L https://raw.githubusercontent.com/pyenv/pyenv-installer/master/bin/pyenv-installer | sh
+# Configure PATH environment for pyenv
 ENV PATH /root/.pyenv/shims:/root/.pyenv/bin:$PATH
 
 # Install all required python versions
-RUN pyenv install 2.7.12
-RUN pyenv install 3.4.4
-RUN pyenv install 3.5.2
-RUN pyenv install 3.6.1
-RUN pyenv global 2.7.12 3.4.4 3.5.2 3.6.1
-RUN pip install --upgrade pip
+RUN \
+  pyenv install 2.7.15 \
+  && pyenv install 3.4.9 \
+  && pyenv install 3.5.6 \
+  && pyenv install 3.6.7 \
+  && pyenv install 3.7.1 \
+  && pyenv global 2.7.15 3.4.9 3.5.6 3.6.7 3.7.1 \
+  && pip install --upgrade pip
 
-# Install tox
-RUN pip install "tox>=3.3,<4.0"
-
-# Cleaning up apk cache space
-RUN rm -rf /var/cache/apk/*
+# Install Python dependencies
+RUN pip install "tox>=3.3,<4.0" "detox>=0.18<1.0"

--- a/dd-trace-py/Dockerfile
+++ b/dd-trace-py/Dockerfile
@@ -1,4 +1,4 @@
-  # Latest image for this Dockerfile: datadog/docker-library:ddtrace_py
+# Latest image for this Dockerfile: datadog/docker-library:ddtrace_py
 FROM alpine:3.4
 
 RUN \


### PR DESCRIPTION
This PR updates the `Dockerfile` for `dd-trace-py`.

1. Reorganize commands 
   1. Make sure to clean up `apk` cache files in the same `RUN` as `apk add`
2. Install all Python versions in the same `RUN` call
3. Update the versions of Python to the latest patch version
4. Add Python `3.7.1` to the image
   1. This is currently not being used by `dd-trace-py`, added for future use
5. Installing [detox](https://pypi.org/project/detox/) `tox` plugin to run test environments in parallel