### PR TITLE
Build and upload  multiple centos images inside hook/build

### DIFF
--- a/dd-trace-php/hooks/build
+++ b/dd-trace-php/hooks/build
@@ -1,0 +1,37 @@
+#!/bin/bash
+EXAMPLE=ddtrace_centos_6_php_54
+TMP=${DOCKER_TAG#ddtrace_centos_}
+
+if [[ $TMP != $DOCKER_TAG ]]; then
+#	CENTOS_VERSION=${TMP%_php_*}
+#	PHP_VERSION=${TMP#*_php_}
+#	echo Build PHP $PHP_VERSION on Centos $CENTOS_VERSION
+#	docker build --build-arg CENTOS_VERSION=$CENTOS_VERSION --build-arg PHP_VERSION=$PHP_VERSION -f $DOCKERFILE_PATH -t $IMAGE_NAME .
+	echo Build all PHP Versions
+	BASE_IMAGE=${DOCKER_REPO}:ddtrace_centos_
+	docker build --build-arg CENTOS_VERSION=6 --build-arg PHP_VERSION=54 -f $DOCKERFILE_PATH -t ${BASE_IMAGE}_6_php_54 .
+	docker build --build-arg CENTOS_VERSION=6 --build-arg PHP_VERSION=56 -f $DOCKERFILE_PATH -t ${BASE_IMAGE}_6_php_56 .
+	docker build --build-arg CENTOS_VERSION=6 --build-arg PHP_VERSION=70 -f $DOCKERFILE_PATH -t ${BASE_IMAGE}_6_php_70 .
+	docker build --build-arg CENTOS_VERSION=6 --build-arg PHP_VERSION=71 -f $DOCKERFILE_PATH -t ${BASE_IMAGE}_6_php_71 .
+	docker build --build-arg CENTOS_VERSION=6 --build-arg PHP_VERSION=72 -f $DOCKERFILE_PATH -t ${BASE_IMAGE}_6_php_72 .
+	docker build --build-arg CENTOS_VERSION=7 --build-arg PHP_VERSION=54 -f $DOCKERFILE_PATH -t ${BASE_IMAGE}_7_php_54 .
+	docker build --build-arg CENTOS_VERSION=7 --build-arg PHP_VERSION=56 -f $DOCKERFILE_PATH -t ${BASE_IMAGE}_7_php_56 .
+	docker build --build-arg CENTOS_VERSION=7 --build-arg PHP_VERSION=70 -f $DOCKERFILE_PATH -t ${BASE_IMAGE}_7_php_70 .
+	docker build --build-arg CENTOS_VERSION=7 --build-arg PHP_VERSION=71 -f $DOCKERFILE_PATH -t ${BASE_IMAGE}_7_php_71 .
+	docker build --build-arg CENTOS_VERSION=7 --build-arg PHP_VERSION=72 -f $DOCKERFILE_PATH -t ${BASE_IMAGE}_7_php_72 .
+	docker build --build-arg CENTOS_VERSION=7 --build-arg PHP_VERSION=73 -f $DOCKERFILE_PATH -t ${BASE_IMAGE}_7_php_73 .
+
+#	docker push ${BASE_IMAGE}_6_php_54
+	docker push ${BASE_IMAGE}_6_php_56
+	docker push ${BASE_IMAGE}_6_php_70
+	docker push ${BASE_IMAGE}_6_php_71
+	docker push ${BASE_IMAGE}_6_php_72
+	docker push ${BASE_IMAGE}_7_php_54
+	docker push ${BASE_IMAGE}_7_php_56
+	docker push ${BASE_IMAGE}_7_php_70
+	docker push ${BASE_IMAGE}_7_php_71
+	docker push ${BASE_IMAGE}_7_php_72
+	docker push ${BASE_IMAGE}_7_php_73
+fi
+
+docker build -f $DOCKERFILE_PATH -t $IMAGE_NAME .

--- a/dd-trace-php/hooks/build
+++ b/dd-trace-php/hooks/build
@@ -1,12 +1,7 @@
 #!/bin/bash
-EXAMPLE=ddtrace_centos_6_php_54
 TMP=${DOCKER_TAG#ddtrace_centos_}
 
 if [[ $TMP != $DOCKER_TAG ]]; then
-#	CENTOS_VERSION=${TMP%_php_*}
-#	PHP_VERSION=${TMP#*_php_}
-#	echo Build PHP $PHP_VERSION on Centos $CENTOS_VERSION
-#	docker build --build-arg CENTOS_VERSION=$CENTOS_VERSION --build-arg PHP_VERSION=$PHP_VERSION -f $DOCKERFILE_PATH -t $IMAGE_NAME .
 	echo Build all PHP Versions
 	BASE_IMAGE=${DOCKER_REPO}:ddtrace_centos_
 	docker build --build-arg CENTOS_VERSION=6 --build-arg PHP_VERSION=54 -f $DOCKERFILE_PATH -t ${BASE_IMAGE}_6_php_54 .
@@ -20,8 +15,8 @@ if [[ $TMP != $DOCKER_TAG ]]; then
 	docker build --build-arg CENTOS_VERSION=7 --build-arg PHP_VERSION=71 -f $DOCKERFILE_PATH -t ${BASE_IMAGE}_7_php_71 .
 	docker build --build-arg CENTOS_VERSION=7 --build-arg PHP_VERSION=72 -f $DOCKERFILE_PATH -t ${BASE_IMAGE}_7_php_72 .
 	docker build --build-arg CENTOS_VERSION=7 --build-arg PHP_VERSION=73 -f $DOCKERFILE_PATH -t ${BASE_IMAGE}_7_php_73 .
-
-#	docker push ${BASE_IMAGE}_6_php_54
+	
+	echo Push all PHP Versions
 	docker push ${BASE_IMAGE}_6_php_56
 	docker push ${BASE_IMAGE}_6_php_70
 	docker push ${BASE_IMAGE}_6_php_71
@@ -32,6 +27,9 @@ if [[ $TMP != $DOCKER_TAG ]]; then
 	docker push ${BASE_IMAGE}_7_php_71
 	docker push ${BASE_IMAGE}_7_php_72
 	docker push ${BASE_IMAGE}_7_php_73
+
+	# This image will be pushed in normal push step
+	#	docker push ${BASE_IMAGE}_6_php_54
 fi
 
 docker build -f $DOCKERFILE_PATH -t $IMAGE_NAME .


### PR DESCRIPTION
Since we need to build 11 different combinations of Centos version and PHP versions, this PR introduces a way to build and upload all those versions programatically by using Dockerhub's `build/hook` and Docker's build-args feature.