### PR TITLE
Fix Centos build broken by incompatibility of legacy dockerhub repository

### DIFF
--- a/dd-trace-php/Dockerfile_centos
+++ b/dd-trace-php/Dockerfile_centos
@@ -4,7 +4,7 @@ ARG CENTOS_VERSION=6
 ARG CENTOS_MINOR_VERSION=1
 RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-${CENTOS_VERSION}.noarch.rpm \
   && rpm -Uvh https://rpms.remirepo.net/enterprise/remi-release-${CENTOS_VERSION}.rpm \
-  && rpm -Uvh http://opensource.wandisco.com/centos/6/git/x86_64/wandisco-git-release-${CENTOS_VERSION}-${CENTOS_MINOR_VERSION}.noarch.rpm \
+  && rpm -Uvh http://opensource.wandisco.com/centos/${CENTOS_VERSION}/git/x86_64/wandisco-git-release-${CENTOS_VERSION}-${CENTOS_MINOR_VERSION}.noarch.rpm \
   && yum install -y yum-utils valgrind git \
   && yum groupinstall -y 'Development Tools' \
   && yum clean all

--- a/dd-trace-php/hooks/build
+++ b/dd-trace-php/hooks/build
@@ -38,6 +38,23 @@ if [[ $TMP != $DOCKER_TAG ]]; then
 	# This image will be buiild/pushed in normal step processing
 	#   docker build --build-arg CENTOS_VERSION=6 --build-arg PHP_VERSION=54 -f $DOCKERFILE_PATH -t ${BASE_IMAGE}_6_php_54 .	
 	#	docker push ${BASE_IMAGE}_6_php_54
+
+	echo Retag upstream ZTS images
+	ZTS_BASE_IMAGE=${DOCKER_REPO}:ddtrace_php_zts_
+	docker tag circleci/php:5.6-zts ${ZTS_BASE_IMAGE}_56
+	docker push ${ZTS_BASE_IMAGE}_56
+
+	docker tag circleci/php:7.0-zts ${ZTS_BASE_IMAGE}_70
+	docker push ${ZTS_BASE_IMAGE}_70
+
+	docker tag circleci/php:7.1-zts ${ZTS_BASE_IMAGE}_71
+	docker push ${ZTS_BASE_IMAGE}_71
+
+	docker tag circleci/php:7.2-zts ${ZTS_BASE_IMAGE}_72
+	docker push ${ZTS_BASE_IMAGE}_72
+
+	docker tag circleci/php:7.3-zts ${ZTS_BASE_IMAGE}_73
+	docker push ${ZTS_BASE_IMAGE}_73
 fi
 
 docker build -f $DOCKERFILE_PATH -t $IMAGE_NAME .

--- a/dd-trace-php/hooks/build
+++ b/dd-trace-php/hooks/build
@@ -11,8 +11,7 @@ fi
 
 if [[ $TMP != $DOCKER_TAG ]]; then
 	echo Build all PHP Versions
-	BASE_IMAGE=${DOCKER_REPO}:ddtrace_centos_
-	docker build --build-arg CENTOS_VERSION=6 --build-arg PHP_VERSION=54 -f $DOCKERFILE_PATH -t ${BASE_IMAGE}_6_php_54 .
+	BASE_IMAGE=${DOCKER_REPO}:ddtrace_centos
 	docker build --build-arg CENTOS_VERSION=6 --build-arg PHP_VERSION=56 -f $DOCKERFILE_PATH -t ${BASE_IMAGE}_6_php_56 .
 	docker build --build-arg CENTOS_VERSION=6 --build-arg PHP_VERSION=70 -f $DOCKERFILE_PATH -t ${BASE_IMAGE}_6_php_70 .
 	docker build --build-arg CENTOS_VERSION=6 --build-arg PHP_VERSION=71 -f $DOCKERFILE_PATH -t ${BASE_IMAGE}_6_php_71 .
@@ -36,7 +35,8 @@ if [[ $TMP != $DOCKER_TAG ]]; then
 	docker push ${BASE_IMAGE}_7_php_72
 	docker push ${BASE_IMAGE}_7_php_73
 
-	# This image will be pushed in normal push step
+	# This image will be buiild/pushed in normal step processing
+	#   docker build --build-arg CENTOS_VERSION=6 --build-arg PHP_VERSION=54 -f $DOCKERFILE_PATH -t ${BASE_IMAGE}_6_php_54 .	
 	#	docker push ${BASE_IMAGE}_6_php_54
 fi
 

--- a/dd-trace-php/hooks/build
+++ b/dd-trace-php/hooks/build
@@ -1,5 +1,13 @@
 #!/bin/bash
 TMP=${DOCKER_TAG#ddtrace_centos_}
+export
+pwd
+
+## Fix for a bug in Dockerhub non automated builds?
+if [[ -z $DOCKERFILE_PATH ]]; then
+	export DOCKERFILE_PATH=${BUILD_PATH#/*/}
+fi
+
 
 if [[ $TMP != $DOCKER_TAG ]]; then
 	echo Build all PHP Versions

--- a/dd-trace-php/hooks/build
+++ b/dd-trace-php/hooks/build
@@ -41,18 +41,24 @@ if [[ $TMP != $DOCKER_TAG ]]; then
 
 	echo Retag upstream ZTS images
 	ZTS_BASE_IMAGE=${DOCKER_REPO}:ddtrace_php_zts_
+
+	docker pull circleci/php:5.6-zts
 	docker tag circleci/php:5.6-zts ${ZTS_BASE_IMAGE}_56
 	docker push ${ZTS_BASE_IMAGE}_56
 
+	docker pull circleci/php:7.0-zts
 	docker tag circleci/php:7.0-zts ${ZTS_BASE_IMAGE}_70
 	docker push ${ZTS_BASE_IMAGE}_70
 
+	docker pull circleci/php:7.1-zts
 	docker tag circleci/php:7.1-zts ${ZTS_BASE_IMAGE}_71
 	docker push ${ZTS_BASE_IMAGE}_71
 
+	docker pull circleci/php:7.2-zts
 	docker tag circleci/php:7.2-zts ${ZTS_BASE_IMAGE}_72
 	docker push ${ZTS_BASE_IMAGE}_72
 
+	docker pull circleci/php:7.3-zts
 	docker tag circleci/php:7.3-zts ${ZTS_BASE_IMAGE}_73
 	docker push ${ZTS_BASE_IMAGE}_73
 fi

--- a/dd-trace-php/hooks/build
+++ b/dd-trace-php/hooks/build
@@ -46,24 +46,24 @@ if [[ $TMP != DOCKER_TAG ]]; then
 	ZTS_BASE_IMAGE=${DOCKER_REPO}:ddtrace_php_zts
 
 	docker pull circleci/php:5.6-zts
-	docker tag circleci/php:5.6-zts ${ZTS_BASE_IMAGE}_56
-	docker push ${ZTS_BASE_IMAGE}_56
+	docker tag circleci/php:5.6-zts ${ZTS_BASE_IMAGE}_5_6
+	docker push ${ZTS_BASE_IMAGE}_5_6
 
 	docker pull circleci/php:7.0-zts
-	docker tag circleci/php:7.0-zts ${ZTS_BASE_IMAGE}_70
-	docker push ${ZTS_BASE_IMAGE}_70
+	docker tag circleci/php:7.0-zts ${ZTS_BASE_IMAGE}_7_0
+	docker push ${ZTS_BASE_IMAGE}_7_0
 
 	docker pull circleci/php:7.1-zts
-	docker tag circleci/php:7.1-zts ${ZTS_BASE_IMAGE}_71
-	docker push ${ZTS_BASE_IMAGE}_71
+	docker tag circleci/php:7.1-zts ${ZTS_BASE_IMAGE}_7_1
+	docker push ${ZTS_BASE_IMAGE}_7_1
 
 	docker pull circleci/php:7.2-zts
-	docker tag circleci/php:7.2-zts ${ZTS_BASE_IMAGE}_72
-	docker push ${ZTS_BASE_IMAGE}_72
+	docker tag circleci/php:7.2-zts ${ZTS_BASE_IMAGE}_7_2
+	docker push ${ZTS_BASE_IMAGE}_7_2
 
 	docker pull circleci/php:7.3-zts
-	docker tag circleci/php:7.3-zts ${ZTS_BASE_IMAGE}_73
-	docker push ${ZTS_BASE_IMAGE}_73
+	docker tag circleci/php:7.3-zts ${ZTS_BASE_IMAGE}_7_3
+	docker push ${ZTS_BASE_IMAGE}_7_3
 
 	exit 0
 fi

--- a/dd-trace-php/hooks/build
+++ b/dd-trace-php/hooks/build
@@ -10,30 +10,30 @@ fi
 if [[ $TMP != $DOCKER_TAG ]]; then
 	echo Build all PHP Versions
 	BASE_IMAGE=${DOCKER_REPO}:ddtrace_centos
-	docker build --build-arg CENTOS_VERSION=6 --build-arg PHP_VERSION=54 -f $DOCKERFILE_PATH -t ${BASE_IMAGE}_6_php_54 .
-	docker build --build-arg CENTOS_VERSION=6 --build-arg PHP_VERSION=56 -f $DOCKERFILE_PATH -t ${BASE_IMAGE}_6_php_56 .
-	docker build --build-arg CENTOS_VERSION=6 --build-arg PHP_VERSION=70 -f $DOCKERFILE_PATH -t ${BASE_IMAGE}_6_php_70 .
-	docker build --build-arg CENTOS_VERSION=6 --build-arg PHP_VERSION=71 -f $DOCKERFILE_PATH -t ${BASE_IMAGE}_6_php_71 .
-	docker build --build-arg CENTOS_VERSION=6 --build-arg PHP_VERSION=72 -f $DOCKERFILE_PATH -t ${BASE_IMAGE}_6_php_72 .
-	docker build --build-arg CENTOS_VERSION=7 --build-arg PHP_VERSION=54 -f $DOCKERFILE_PATH -t ${BASE_IMAGE}_7_php_54 .
-	docker build --build-arg CENTOS_VERSION=7 --build-arg PHP_VERSION=56 -f $DOCKERFILE_PATH -t ${BASE_IMAGE}_7_php_56 .
-	docker build --build-arg CENTOS_VERSION=7 --build-arg PHP_VERSION=70 -f $DOCKERFILE_PATH -t ${BASE_IMAGE}_7_php_70 .
-	docker build --build-arg CENTOS_VERSION=7 --build-arg PHP_VERSION=71 -f $DOCKERFILE_PATH -t ${BASE_IMAGE}_7_php_71 .
-	docker build --build-arg CENTOS_VERSION=7 --build-arg PHP_VERSION=72 -f $DOCKERFILE_PATH -t ${BASE_IMAGE}_7_php_72 .
-	docker build --build-arg CENTOS_VERSION=7 --build-arg PHP_VERSION=73 -f $DOCKERFILE_PATH -t ${BASE_IMAGE}_7_php_73 .
+	docker build --build-arg CENTOS_VERSION=6 --build-arg PHP_VERSION=54 -f $DOCKERFILE_PATH -t ${BASE_IMAGE}_6_php_5_4 .
+	docker build --build-arg CENTOS_VERSION=6 --build-arg PHP_VERSION=56 -f $DOCKERFILE_PATH -t ${BASE_IMAGE}_6_php_5_6 .
+	docker build --build-arg CENTOS_VERSION=6 --build-arg PHP_VERSION=70 -f $DOCKERFILE_PATH -t ${BASE_IMAGE}_6_php_7_0 .
+	docker build --build-arg CENTOS_VERSION=6 --build-arg PHP_VERSION=71 -f $DOCKERFILE_PATH -t ${BASE_IMAGE}_6_php_7_1 .
+	docker build --build-arg CENTOS_VERSION=6 --build-arg PHP_VERSION=72 -f $DOCKERFILE_PATH -t ${BASE_IMAGE}_6_php_7_2 .
+	docker build --build-arg CENTOS_VERSION=7 --build-arg PHP_VERSION=54 -f $DOCKERFILE_PATH -t ${BASE_IMAGE}_7_php_5_4 .
+	docker build --build-arg CENTOS_VERSION=7 --build-arg PHP_VERSION=56 -f $DOCKERFILE_PATH -t ${BASE_IMAGE}_7_php_5_6 .
+	docker build --build-arg CENTOS_VERSION=7 --build-arg PHP_VERSION=70 -f $DOCKERFILE_PATH -t ${BASE_IMAGE}_7_php_7_0 .
+	docker build --build-arg CENTOS_VERSION=7 --build-arg PHP_VERSION=71 -f $DOCKERFILE_PATH -t ${BASE_IMAGE}_7_php_7_1 .
+	docker build --build-arg CENTOS_VERSION=7 --build-arg PHP_VERSION=72 -f $DOCKERFILE_PATH -t ${BASE_IMAGE}_7_php_7_2 .
+	docker build --build-arg CENTOS_VERSION=7 --build-arg PHP_VERSION=73 -f $DOCKERFILE_PATH -t ${BASE_IMAGE}_7_php_7_3 .
 	
 	echo Push all PHP Versions
-	docker push ${BASE_IMAGE}_6_php_54
-	docker push ${BASE_IMAGE}_6_php_56
-	docker push ${BASE_IMAGE}_6_php_70
-	docker push ${BASE_IMAGE}_6_php_71
-	docker push ${BASE_IMAGE}_6_php_72
-	docker push ${BASE_IMAGE}_7_php_54
-	docker push ${BASE_IMAGE}_7_php_56
-	docker push ${BASE_IMAGE}_7_php_70
-	docker push ${BASE_IMAGE}_7_php_71
-	docker push ${BASE_IMAGE}_7_php_72
-	docker push ${BASE_IMAGE}_7_php_73
+	docker push ${BASE_IMAGE}_6_php_5_4
+	docker push ${BASE_IMAGE}_6_php_5_6
+	docker push ${BASE_IMAGE}_6_php_7_0
+	docker push ${BASE_IMAGE}_6_php_7_1
+	docker push ${BASE_IMAGE}_6_php_7_2
+	docker push ${BASE_IMAGE}_7_php_5_4
+	docker push ${BASE_IMAGE}_7_php_5_6
+	docker push ${BASE_IMAGE}_7_php_7_0
+	docker push ${BASE_IMAGE}_7_php_7_1
+	docker push ${BASE_IMAGE}_7_php_7_2
+	docker push ${BASE_IMAGE}_7_php_7_3
 
 	exit 0
 fi

--- a/dd-trace-php/hooks/build
+++ b/dd-trace-php/hooks/build
@@ -1,9 +1,7 @@
 #!/bin/bash
 TMP=${DOCKER_TAG#ddtrace_centos_}
-export
-pwd
 
-## Fix for a bug in Dockerhub non automated builds?
+## Fix for a bug in Dockerhub legacy build process
 if [[ -z $DOCKERFILE_PATH ]]; then
 	export DOCKERFILE_PATH=${BUILD_PATH#/*/}
 fi
@@ -12,6 +10,7 @@ fi
 if [[ $TMP != $DOCKER_TAG ]]; then
 	echo Build all PHP Versions
 	BASE_IMAGE=${DOCKER_REPO}:ddtrace_centos
+	docker build --build-arg CENTOS_VERSION=6 --build-arg PHP_VERSION=54 -f $DOCKERFILE_PATH -t ${BASE_IMAGE}_6_php_54 .
 	docker build --build-arg CENTOS_VERSION=6 --build-arg PHP_VERSION=56 -f $DOCKERFILE_PATH -t ${BASE_IMAGE}_6_php_56 .
 	docker build --build-arg CENTOS_VERSION=6 --build-arg PHP_VERSION=70 -f $DOCKERFILE_PATH -t ${BASE_IMAGE}_6_php_70 .
 	docker build --build-arg CENTOS_VERSION=6 --build-arg PHP_VERSION=71 -f $DOCKERFILE_PATH -t ${BASE_IMAGE}_6_php_71 .
@@ -24,6 +23,7 @@ if [[ $TMP != $DOCKER_TAG ]]; then
 	docker build --build-arg CENTOS_VERSION=7 --build-arg PHP_VERSION=73 -f $DOCKERFILE_PATH -t ${BASE_IMAGE}_7_php_73 .
 	
 	echo Push all PHP Versions
+	docker push ${BASE_IMAGE}_6_php_54
 	docker push ${BASE_IMAGE}_6_php_56
 	docker push ${BASE_IMAGE}_6_php_70
 	docker push ${BASE_IMAGE}_6_php_71
@@ -35,12 +35,15 @@ if [[ $TMP != $DOCKER_TAG ]]; then
 	docker push ${BASE_IMAGE}_7_php_72
 	docker push ${BASE_IMAGE}_7_php_73
 
-	# This image will be buiild/pushed in normal step processing
-	#   docker build --build-arg CENTOS_VERSION=6 --build-arg PHP_VERSION=54 -f $DOCKERFILE_PATH -t ${BASE_IMAGE}_6_php_54 .	
-	#	docker push ${BASE_IMAGE}_6_php_54
+	exit 0
+fi
+
+TMP=${DOCKER_TAG#ddtrace_php_zts_}
+if [[ $TMP != DOCKER_TAG ]]; then
+	# Instead of building images we simply fetch source images and tag them with datadog repo and tag to ensure they only change in a controlled manner
 
 	echo Retag upstream ZTS images
-	ZTS_BASE_IMAGE=${DOCKER_REPO}:ddtrace_php_zts_
+	ZTS_BASE_IMAGE=${DOCKER_REPO}:ddtrace_php_zts
 
 	docker pull circleci/php:5.6-zts
 	docker tag circleci/php:5.6-zts ${ZTS_BASE_IMAGE}_56
@@ -61,6 +64,9 @@ if [[ $TMP != $DOCKER_TAG ]]; then
 	docker pull circleci/php:7.3-zts
 	docker tag circleci/php:7.3-zts ${ZTS_BASE_IMAGE}_73
 	docker push ${ZTS_BASE_IMAGE}_73
+
+	exit 0
 fi
 
+# defualt build
 docker build -f $DOCKERFILE_PATH -t $IMAGE_NAME .


### PR DESCRIPTION
Currently dockerhub is in the process of migrating to new repository setup.

The centos build being developed on new repository setups, turned out not to be compatible with legacy setup.

Additionally:
- there was an extra `_` in the tag that slipped through
- Too old Git meant that the images couldn't be used on circleci as  build images (this PR fixes the installation of newer Git)
- this PR adds a way to Re tag original PHP ZTS images as datadog images to make sure that we do not have a rug pulled from under our feet, when something is deprecated/removed in the upstream repository


Note: old repository setups should automatically be upgrade to new over coming months (according to Dockerhub docs)