### PR TITLE
[dd-opentracing-cpp] add tools for test container

### DIFF
--- a/dd-opentracing-cpp/test/0.3.1/Dockerfile
+++ b/dd-opentracing-cpp/test/0.3.1/Dockerfile
@@ -3,11 +3,12 @@ FROM ubuntu:18.04
 RUN apt-get update && \
   apt-get install -y \
   # Basic circleci utils
-  ca-certificates git curl wget tar sudo \
+  ca-certificates git curl wget tar sudo iproute2 \
   # Integration test tools
   lsb-release jq openjdk-8-jre golang
 
-# Wiremock for running intergration tests
+# Wiremock for running integration tests
 ADD http://repo1.maven.org/maven2/com/github/tomakehurst/wiremock-standalone/2.18.0/wiremock-standalone-2.18.0.jar wiremock-standalone-2.18.0.jar
 RUN printf "#!/bin/bash\nset -x\njava -jar $(pwd)/wiremock-standalone-2.18.0.jar \"\$@\"\n" > /usr/local/bin/wiremock && \
   chmod a+x /usr/local/bin/wiremock
+RUN go get github.com/jakm/msgpack-cli


### PR DESCRIPTION
Putting these things into the base test image.
This makes things nicer while updating and locally testing the integration tests.