### PR TITLE
[dd-trace-py] Add maridb compat dev package

### DIFF
--- a/dd-trace-py/Dockerfile
+++ b/dd-trace-py/Dockerfile
@@ -17,6 +17,7 @@ RUN \
       libbz2-dev \
       libffi-dev \
       libmariadb-dev \
+      libmariadb-dev-compat \
       libmemcached-dev \
       libmemcached-dev \
       libncurses5 \


### PR DESCRIPTION
We did not have `mysql_config` available so could not build MySQL C-extensions for Python.