### PR TITLE
Update Bundler to 1.17.3 for dd-trace-rb

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,9 @@ Currently available tags:
 * [`ddtrace_rb_2_1_10`](https://github.com/DataDog/docker-library/tree/master/dd-trace-rb/2.1.10): Test runner for Ruby version 2.1.10
 * [`ddtrace_rb_2_2_10`](https://github.com/DataDog/docker-library/tree/master/dd-trace-rb/2.2.10): Test runner for Ruby version 2.2.10
 * [`ddtrace_rb_2_3_7`](https://github.com/DataDog/docker-library/tree/master/dd-trace-rb/2.3.7): Test runner for Ruby version 2.3.7
+* [`ddtrace_rb_2_3_8`](https://github.com/DataDog/docker-library/tree/master/dd-trace-rb/2.3.8): Test runner for Ruby version 2.3.8
 * [`ddtrace_rb_2_4_4`](https://github.com/DataDog/docker-library/tree/master/dd-trace-rb/2.4.4): Test runner for Ruby version 2.4.4
+* [`ddtrace_rb_2_4_6`](https://github.com/DataDog/docker-library/tree/master/dd-trace-rb/2.4.6): Test runner for Ruby version 2.4.6
 * [`ddtrace_php_5_6`](https://github.com/DataDog/docker-library/tree/master/dd-trace-php/Dockerfile_56): Test runner for PHP version 5.6
 * [`ddtrace_php_7_0`](https://github.com/DataDog/docker-library/tree/master/dd-trace-php/Dockerfile_70): Test runner for PHP version 7.0
 * [`ddtrace_php_7_1`](https://github.com/DataDog/docker-library/tree/master/dd-trace-php/Dockerfile_71): Test runner for PHP version 7.1

--- a/dd-trace-rb/1.9.3/Dockerfile
+++ b/dd-trace-rb/1.9.3/Dockerfile
@@ -1,6 +1,10 @@
 # Last version: https://github.com/docker-library/ruby/blob/90c4e3be58d565007c518d311d4bd05086a1638c/1.9/Dockerfile
 FROM ruby:1.9.3
 
+# Add Jessie repos
+# Fixes https://superuser.com/questions/1423486/issue-with-fetching-http-deb-debian-org-debian-dists-jessie-updates-inrelease
+RUN printf "deb http://archive.debian.org/debian/ jessie main\ndeb-src http://archive.debian.org/debian/ jessie main\ndeb http://security.debian.org jessie/updates main\ndeb-src http://security.debian.org jessie/updates main" > /etc/apt/sources.list
+
 # Make apt non-interactive
 RUN echo 'APT::Get::Assume-Yes "true";' > /etc/apt/apt.conf.d/90circleci \
   && echo 'DPkg::Options "--force-confnew";' >> /etc/apt/apt.conf.d/90circleci
@@ -59,7 +63,7 @@ RUN DOCKERIZE_URL="https://circle-downloads.s3.amazonaws.com/circleci-images/cac
   && dockerize --version
 
 # Install RubyGems
-RUN gem update --system
+RUN gem update --system 2.7.9
 RUN gem install bundler -v '1.17.3'
 ENV BUNDLE_SILENCE_ROOT_WARNING 1
 

--- a/dd-trace-rb/1.9.3/Dockerfile
+++ b/dd-trace-rb/1.9.3/Dockerfile
@@ -60,7 +60,7 @@ RUN DOCKERIZE_URL="https://circle-downloads.s3.amazonaws.com/circleci-images/cac
 
 # Install RubyGems
 RUN gem update --system
-RUN gem install bundler
+RUN gem install bundler -v '1.17.3'
 ENV BUNDLE_SILENCE_ROOT_WARNING 1
 
 RUN mkdir /app

--- a/dd-trace-rb/2.0.0/Dockerfile
+++ b/dd-trace-rb/2.0.0/Dockerfile
@@ -60,7 +60,7 @@ RUN DOCKERIZE_URL="https://circle-downloads.s3.amazonaws.com/circleci-images/cac
 
 # Install RubyGems
 RUN gem update --system
-RUN gem install bundler
+RUN gem install bundler -v '1.17.3'
 ENV BUNDLE_SILENCE_ROOT_WARNING 1
 
 RUN mkdir /app

--- a/dd-trace-rb/2.0.0/Dockerfile
+++ b/dd-trace-rb/2.0.0/Dockerfile
@@ -1,6 +1,10 @@
 # Last version: https://github.com/docker-library/ruby/blob/c387c6c3a2505060514e31c247cb37d22c944e55/2.0/Dockerfile
 FROM ruby:2.0.0
 
+# Add Jessie repos
+# Fixes https://superuser.com/questions/1423486/issue-with-fetching-http-deb-debian-org-debian-dists-jessie-updates-inrelease
+RUN printf "deb http://archive.debian.org/debian/ jessie main\ndeb-src http://archive.debian.org/debian/ jessie main\ndeb http://security.debian.org jessie/updates main\ndeb-src http://security.debian.org jessie/updates main" > /etc/apt/sources.list
+
 # Make apt non-interactive
 RUN echo 'APT::Get::Assume-Yes "true";' > /etc/apt/apt.conf.d/90circleci \
   && echo 'DPkg::Options "--force-confnew";' >> /etc/apt/apt.conf.d/90circleci
@@ -59,7 +63,7 @@ RUN DOCKERIZE_URL="https://circle-downloads.s3.amazonaws.com/circleci-images/cac
   && dockerize --version
 
 # Install RubyGems
-RUN gem update --system
+RUN gem update --system 2.7.9
 RUN gem install bundler -v '1.17.3'
 ENV BUNDLE_SILENCE_ROOT_WARNING 1
 

--- a/dd-trace-rb/2.1.10/Dockerfile
+++ b/dd-trace-rb/2.1.10/Dockerfile
@@ -1,6 +1,10 @@
 # Last version: https://github.com/docker-library/ruby/blob/99def14400fcd612782367830836dfcbc10c8c50/2.1/Dockerfile
 FROM ruby:2.1.10
 
+# Add Jessie repos
+# Fixes https://superuser.com/questions/1423486/issue-with-fetching-http-deb-debian-org-debian-dists-jessie-updates-inrelease
+RUN printf "deb http://archive.debian.org/debian/ jessie main\ndeb-src http://archive.debian.org/debian/ jessie main\ndeb http://security.debian.org jessie/updates main\ndeb-src http://security.debian.org jessie/updates main" > /etc/apt/sources.list
+
 # Make apt non-interactive
 RUN echo 'APT::Get::Assume-Yes "true";' > /etc/apt/apt.conf.d/90circleci \
   && echo 'DPkg::Options "--force-confnew";' >> /etc/apt/apt.conf.d/90circleci
@@ -59,7 +63,7 @@ RUN DOCKERIZE_URL="https://circle-downloads.s3.amazonaws.com/circleci-images/cac
   && dockerize --version
 
 # Install RubyGems
-RUN gem update --system
+RUN gem update --system 2.7.9
 RUN gem install bundler -v '1.17.3'
 ENV BUNDLE_SILENCE_ROOT_WARNING 1
 

--- a/dd-trace-rb/2.1.10/Dockerfile
+++ b/dd-trace-rb/2.1.10/Dockerfile
@@ -60,7 +60,7 @@ RUN DOCKERIZE_URL="https://circle-downloads.s3.amazonaws.com/circleci-images/cac
 
 # Install RubyGems
 RUN gem update --system
-RUN gem install bundler
+RUN gem install bundler -v '1.17.3'
 ENV BUNDLE_SILENCE_ROOT_WARNING 1
 
 RUN mkdir /app

--- a/dd-trace-rb/2.2.10/Dockerfile
+++ b/dd-trace-rb/2.2.10/Dockerfile
@@ -1,6 +1,10 @@
 # Last version: https://github.com/docker-library/ruby/blob/395cce4eba52917eb9a40c72d50703a1ce9e1acd/2.2/jessie/Dockerfile
 FROM ruby:2.2.10
 
+# Add Jessie repos
+# Fixes https://superuser.com/questions/1423486/issue-with-fetching-http-deb-debian-org-debian-dists-jessie-updates-inrelease
+RUN printf "deb http://archive.debian.org/debian/ jessie main\ndeb-src http://archive.debian.org/debian/ jessie main\ndeb http://security.debian.org jessie/updates main\ndeb-src http://security.debian.org jessie/updates main" > /etc/apt/sources.list
+
 # Make apt non-interactive
 RUN echo 'APT::Get::Assume-Yes "true";' > /etc/apt/apt.conf.d/90circleci \
   && echo 'DPkg::Options "--force-confnew";' >> /etc/apt/apt.conf.d/90circleci
@@ -59,7 +63,7 @@ RUN DOCKERIZE_URL="https://circle-downloads.s3.amazonaws.com/circleci-images/cac
   && dockerize --version
 
 # Install RubyGems
-RUN gem update --system
+RUN gem update --system 2.7.9
 RUN gem install bundler -v '1.17.3'
 ENV BUNDLE_SILENCE_ROOT_WARNING 1
 

--- a/dd-trace-rb/2.2.10/Dockerfile
+++ b/dd-trace-rb/2.2.10/Dockerfile
@@ -60,7 +60,7 @@ RUN DOCKERIZE_URL="https://circle-downloads.s3.amazonaws.com/circleci-images/cac
 
 # Install RubyGems
 RUN gem update --system
-RUN gem install bundler
+RUN gem install bundler -v '1.17.3'
 ENV BUNDLE_SILENCE_ROOT_WARNING 1
 
 RUN mkdir /app

--- a/dd-trace-rb/2.3.8/Dockerfile
+++ b/dd-trace-rb/2.3.8/Dockerfile
@@ -1,0 +1,73 @@
+# Current version: https://github.com/docker-library/ruby/blob/31f66490fdb837ddcc5896e3275f2188f2b7b6dd/2.3/stretch/Dockerfile
+FROM ruby:2.3.8
+
+# Make apt non-interactive
+RUN echo 'APT::Get::Assume-Yes "true";' > /etc/apt/apt.conf.d/90circleci \
+  && echo 'DPkg::Options "--force-confnew";' >> /etc/apt/apt.conf.d/90circleci
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install required packages
+RUN set -ex; \
+        apt-get update; \
+        mkdir -p /usr/share/man/man1; \
+        apt-get install -y --no-install-recommends \
+            git mercurial xvfb \
+            locales sudo openssh-client ca-certificates tar gzip parallel \
+            net-tools netcat unzip zip bzip2 gnupg curl wget \
+            tzdata rsync vim; \
+        rm -rf /var/lib/apt/lists/*;
+
+# Set timezone to UTC by default
+RUN ln -sf /usr/share/zoneinfo/Etc/UTC /etc/localtime
+
+# Set language
+RUN locale-gen en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+
+# Install jq
+RUN JQ_URL="https://circle-downloads.s3.amazonaws.com/circleci-images/cache/linux-amd64/jq-latest" \
+  && curl --silent --show-error --location --fail --retry 3 --output /usr/bin/jq $JQ_URL \
+  && chmod +x /usr/bin/jq \
+  && jq --version
+
+# Install Docker
+RUN set -ex \
+  && export DOCKER_VERSION=$(curl --silent --fail --retry 3 https://download.docker.com/linux/static/stable/x86_64/ | grep -o -e 'docker-[.0-9]*-ce\.tgz' | sort -r | head -n 1) \
+  && DOCKER_URL="https://download.docker.com/linux/static/stable/x86_64/${DOCKER_VERSION}" \
+  && echo Docker URL: $DOCKER_URL \
+  && curl --silent --show-error --location --fail --retry 3 --output /tmp/docker.tgz "${DOCKER_URL}" \
+  && ls -lha /tmp/docker.tgz \
+  && tar -xz -C /tmp -f /tmp/docker.tgz \
+  && mv /tmp/docker/* /usr/bin \
+  && rm -rf /tmp/docker /tmp/docker.tgz \
+  && which docker \
+  && (docker version || true)
+
+# Install Docker Compose
+RUN COMPOSE_URL="https://circle-downloads.s3.amazonaws.com/circleci-images/cache/linux-amd64/docker-compose-latest" \
+  && curl --silent --show-error --location --fail --retry 3 --output /usr/bin/docker-compose $COMPOSE_URL \
+  && chmod +x /usr/bin/docker-compose \
+  && docker-compose version
+
+# Install Dockerize
+RUN DOCKERIZE_URL="https://circle-downloads.s3.amazonaws.com/circleci-images/cache/linux-amd64/dockerize-latest.tar.gz" \
+  && curl --silent --show-error --location --fail --retry 3 --output /tmp/dockerize-linux-amd64.tar.gz $DOCKERIZE_URL \
+  && tar -C /usr/local/bin -xzvf /tmp/dockerize-linux-amd64.tar.gz \
+  && rm -rf /tmp/dockerize-linux-amd64.tar.gz \
+  && dockerize --version
+
+# Install RubyGems
+RUN gem update --system
+RUN mkdir -p "$GEM_HOME" && chmod -R 777 "$GEM_HOME"
+
+# Install RubyGems
+RUN gem update --system
+RUN gem install bundler
+ENV BUNDLE_SILENCE_ROOT_WARNING 1
+
+RUN mkdir /app
+WORKDIR /app
+
+CMD ["/bin/sh"]

--- a/dd-trace-rb/2.4.6/Dockerfile
+++ b/dd-trace-rb/2.4.6/Dockerfile
@@ -1,0 +1,73 @@
+# Current version: https://github.com/docker-library/ruby/blob/802421922ef50cfa05c89a3c619992acf4329986/2.4/jessie/Dockerfile
+FROM ruby:2.4.6
+
+# Make apt non-interactive
+RUN echo 'APT::Get::Assume-Yes "true";' > /etc/apt/apt.conf.d/90circleci \
+  && echo 'DPkg::Options "--force-confnew";' >> /etc/apt/apt.conf.d/90circleci
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install required packages
+RUN set -ex; \
+        apt-get update; \
+        mkdir -p /usr/share/man/man1; \
+        apt-get install -y --no-install-recommends \
+            git mercurial xvfb \
+            locales sudo openssh-client ca-certificates tar gzip parallel \
+            net-tools netcat unzip zip bzip2 gnupg curl wget \
+            tzdata rsync vim; \
+        rm -rf /var/lib/apt/lists/*;
+
+# Set timezone to UTC by default
+RUN ln -sf /usr/share/zoneinfo/Etc/UTC /etc/localtime
+
+# Set language
+RUN locale-gen en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+
+# Install jq
+RUN JQ_URL="https://circle-downloads.s3.amazonaws.com/circleci-images/cache/linux-amd64/jq-latest" \
+  && curl --silent --show-error --location --fail --retry 3 --output /usr/bin/jq $JQ_URL \
+  && chmod +x /usr/bin/jq \
+  && jq --version
+
+# Install Docker
+RUN set -ex \
+  && export DOCKER_VERSION=$(curl --silent --fail --retry 3 https://download.docker.com/linux/static/stable/x86_64/ | grep -o -e 'docker-[.0-9]*-ce\.tgz' | sort -r | head -n 1) \
+  && DOCKER_URL="https://download.docker.com/linux/static/stable/x86_64/${DOCKER_VERSION}" \
+  && echo Docker URL: $DOCKER_URL \
+  && curl --silent --show-error --location --fail --retry 3 --output /tmp/docker.tgz "${DOCKER_URL}" \
+  && ls -lha /tmp/docker.tgz \
+  && tar -xz -C /tmp -f /tmp/docker.tgz \
+  && mv /tmp/docker/* /usr/bin \
+  && rm -rf /tmp/docker /tmp/docker.tgz \
+  && which docker \
+  && (docker version || true)
+
+# Install Docker Compose
+RUN COMPOSE_URL="https://circle-downloads.s3.amazonaws.com/circleci-images/cache/linux-amd64/docker-compose-latest" \
+  && curl --silent --show-error --location --fail --retry 3 --output /usr/bin/docker-compose $COMPOSE_URL \
+  && chmod +x /usr/bin/docker-compose \
+  && docker-compose version
+
+# Install Dockerize
+RUN DOCKERIZE_URL="https://circle-downloads.s3.amazonaws.com/circleci-images/cache/linux-amd64/dockerize-latest.tar.gz" \
+  && curl --silent --show-error --location --fail --retry 3 --output /tmp/dockerize-linux-amd64.tar.gz $DOCKERIZE_URL \
+  && tar -C /usr/local/bin -xzvf /tmp/dockerize-linux-amd64.tar.gz \
+  && rm -rf /tmp/dockerize-linux-amd64.tar.gz \
+  && dockerize --version
+
+# Install RubyGems
+RUN gem update --system
+RUN mkdir -p "$GEM_HOME" && chmod -R 777 "$GEM_HOME"
+
+# Install RubyGems
+RUN gem update --system
+RUN gem install bundler
+ENV BUNDLE_SILENCE_ROOT_WARNING 1
+
+RUN mkdir /app
+WORKDIR /app
+
+CMD ["/bin/sh"]


### PR DESCRIPTION
These images used for testing with dd-trace-rb on CircleCI were using an old version of Bundler that caused dependencies to resolve incorrectly.

This pull request updates the images to a newer version of bundler, so dd-trace-rb can use these updated images to avoid build failures.