### PR TITLE
Fix Ruby 2.3 Bundler to 1.17.3 for dd-trace-rb

### DIFF
--- a/dd-trace-rb/2.3.7/Dockerfile
+++ b/dd-trace-rb/2.3.7/Dockerfile
@@ -64,7 +64,9 @@ RUN mkdir -p "$GEM_HOME" && chmod -R 777 "$GEM_HOME"
 
 # Install RubyGems
 RUN gem update --system
-RUN gem install bundler
+# Ruby 2.3 can support Bundler 2+
+# But hold back to < 2 for now, because some dependencies require it.
+RUN gem install bundler -v '1.17.3'
 ENV BUNDLE_SILENCE_ROOT_WARNING 1
 
 RUN mkdir /app

--- a/dd-trace-rb/2.3.8/Dockerfile
+++ b/dd-trace-rb/2.3.8/Dockerfile
@@ -64,7 +64,9 @@ RUN mkdir -p "$GEM_HOME" && chmod -R 777 "$GEM_HOME"
 
 # Install RubyGems
 RUN gem update --system
-RUN gem install bundler
+# Ruby 2.3 can support Bundler 2+
+# But hold back to < 2 for now, because some dependencies require it.
+RUN gem install bundler -v '1.17.3'
 ENV BUNDLE_SILENCE_ROOT_WARNING 1
 
 RUN mkdir /app


### PR DESCRIPTION
As a follow up from https://github.com/DataDog/docker-library/pull/44, although Bundler 2+ is fine for Ruby 2.3, some libraries (Rails < 5) are not compatible with Bundler 2.0. This PR holds back Bundler for Ruby 2.3 to the 1.x branch.