### PR TITLE
Add Centos8 fake systemd image

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Currently available tags:
 * [`ansible_2_8`](https://github.com/DataDog/docker-library/tree/master/ansible/2.8): Ansible v2.8
 * [`chef_kitchen_systemd_centos_6`](https://github.com/DataDog/docker-library/tree/master/chef-kitchen/systemd/centos6): Chef Kitchen image for testing systemd services on Centos 6
 * [`chef_kitchen_systemd_centos_7`](https://github.com/DataDog/docker-library/tree/master/chef-kitchen/systemd/centos7): Chef Kitchen image for testing systemd services on Centos 7
+* [`chef_kitchen_systemd_centos_8`](https://github.com/DataDog/docker-library/tree/master/chef-kitchen/systemd/centos8): Chef Kitchen image for testing systemd services on Centos 8
 * [`couch_2_3`](https://github.com/DataDog/docker-library/tree/master/couch/2.3): Couch v2.3.1 with development cluster
 * [`dd_opentracing_cpp_ubuntu_16.04_0_2_1`](https://github.com/DataDog/docker-library/tree/master/dd-opentracing-cpp/ubuntu_16.04/0.2.1): Base image for CircleCI build of C++ OpenTracing integration (Ubuntu 16.04)
 * [`dd_opentracing_cpp_ubuntu_18.04_0_2_1`](https://github.com/DataDog/docker-library/tree/master/dd-opentracing-cpp/ubuntu_18.04/0.2.1): Base image for CircleCI build of C++ OpenTracing integration (Ubuntu 18.04)

--- a/chef-kitchen/systemd/centos8/Dockerfile
+++ b/chef-kitchen/systemd/centos8/Dockerfile
@@ -1,0 +1,20 @@
+FROM centos:8
+MAINTAINER Karim Bogtob <karim.bogtob@datadoghq.com>
+
+RUN yum install -y epel-release
+RUN yum search openssh
+RUN yum install -y openssh-server openssh-clients
+RUN yum install -y ruby-2.5.5
+RUN yum install -y python2-2.7.16
+# binding python2 as default python interpreter for fake systemctl
+RUN ln -s /usr/bin/python2 /usr/bin/python
+
+# This is using the multistage docker build as described here:
+# https://docs.docker.com/develop/develop-images/multistage-build/
+
+# the temporary docker-library:chef_kitchen_systemd_scripts_0.1 is described in this repository
+COPY --from=datadog/docker-library:chef_kitchen_systemd_scripts_0.1 /usr/bin/systemctl /usr/bin/systemctl
+COPY --from=datadog/docker-library:chef_kitchen_systemd_scripts_0.1 /usr/bin/systemctl /usr/bin/systemd
+COPY --from=datadog/docker-library:chef_kitchen_systemd_scripts_0.1 /root/start.sh /root/start.sh
+
+CMD [ "/root/start.sh" ]


### PR DESCRIPTION
### What does this PR do?

It adds a new Centos 8 image with a fake systemd for kitchen docker tests on CircleCI

### Motivation

The puppet datadog agent role tests the role against centos 8.