### PR TITLE
Add a validator for snmprec file

### DIFF
--- a/snmp/Dockerfile
+++ b/snmp/Dockerfile
@@ -1,10 +1,18 @@
-FROM python:alpine
-
-RUN apk add --no-cache gcc libc-dev && \
-    addgroup -S snmpsim && \
-    adduser -S snmpsim -G snmpsim && \
-    pip install --no-cache-dir snmpsim
+FROM debian:stable-slim
 
 ADD entrypoint.sh /usr/bin/entrypoint.sh
 RUN chmod +x /usr/bin/entrypoint.sh
-ENTRYPOINT ["entrypoint.sh", "--agent-udpv4-endpoint=0.0.0.0:1161", "--process-user=snmpsim", "--process-group=snmpsim"]
+
+RUN apt-get update \
+    && apt-get install -y curl python gpg procps \
+    && apt-get clean
+RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py \
+    && python get-pip.py \
+    && rm get-pip.py
+RUN pip install snmpsim
+RUN groupadd snmpsim && useradd snmpsim -g snmpsim
+
+VOLUME /usr/snmpsim/data
+USER snmpsim
+
+ENTRYPOINT ["entrypoint.sh", "--agent-udpv4-endpoint=0.0.0.0:1161"]

--- a/snmp/Dockerfile
+++ b/snmp/Dockerfile
@@ -1,14 +1,10 @@
-FROM debian:stable-slim
+FROM python:alpine
 
-RUN apt-get update \
-    && apt-get install -y curl python gpg procps \
-    && apt-get clean
-RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py \
-    && python get-pip.py \
-    && rm get-pip.py
-RUN pip install snmpsim
-RUN groupadd snmpsim && useradd snmpsim -g snmpsim
+RUN apk add --no-cache gcc libc-dev && \
+    addgroup -S snmpsim && \
+    adduser -S snmpsim -G snmpsim && \
+    pip install --no-cache-dir snmpsim
 
-VOLUME /usr/snmpsim/data
-
-ENTRYPOINT ["snmpsimd.py", "--agent-udpv4-endpoint=0.0.0.0:1161", "--process-user=snmpsim", "--process-group=snmpsim"]
+ADD entrypoint.sh /usr/bin/entrypoint.sh
+RUN chmod +x /usr/bin/entrypoint.sh
+ENTRYPOINT ["entrypoint.sh", "--agent-udpv4-endpoint=0.0.0.0:1161", "--process-user=snmpsim", "--process-group=snmpsim"]

--- a/snmp/entrypoint.sh
+++ b/snmp/entrypoint.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+exit_code=0
+for f in /usr/snmpsim/data/*.snmprec
+do
+  if ! sort -c -V "$f" 1>/dev/null 2>&1; then
+    echo -e "\e[31mFile $f is not sorted, please fix your file with the command 'sort -V $f | uniq'!\e[0m"
+    exit_code=$((exit_code+1))
+  fi
+done
+
+if [ ! $exit_code -eq 0 ]; then
+  exit $exit_code
+fi
+snmpsimd.py "$@"


### PR DESCRIPTION
The snmp container we use for simulating data is using `snmpsim` to serve the content of the fixture files. Those files have to be sorted, otherwise tests will fail with hard to debug issues.

This PR adds a custom entrypoint for the snmp container, which will first assert the validity of those fixture files and then run `snmpsimd.py`