### PR TITLE
Add OpenSUSE systemd image

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Currently available tags:
 * [`chef_kitchen_systemd_centos_6`](https://github.com/DataDog/docker-library/tree/master/chef-kitchen/systemd/centos6): Chef Kitchen image for testing systemd services on Centos 6
 * [`chef_kitchen_systemd_centos_7`](https://github.com/DataDog/docker-library/tree/master/chef-kitchen/systemd/centos7): Chef Kitchen image for testing systemd services on Centos 7
 * [`chef_kitchen_systemd_centos_8`](https://github.com/DataDog/docker-library/tree/master/chef-kitchen/systemd/centos8): Chef Kitchen image for testing systemd services on Centos 8
+* [`chef_kitchen_systemd_opensuse_leap_15`](https://github.com/DataDog/docker-library/tree/master/chef-kitchen/systemd/opensuse): Chef Kitchen image for testing systemd services on OpenSUSE Leap 15
 * [`couch_2_3`](https://github.com/DataDog/docker-library/tree/master/couch/2.3): Couch v2.3.1 with development cluster
 * [`dd_opentracing_cpp_ubuntu_16.04_0_2_1`](https://github.com/DataDog/docker-library/tree/master/dd-opentracing-cpp/ubuntu_16.04/0.2.1): Base image for CircleCI build of C++ OpenTracing integration (Ubuntu 16.04)
 * [`dd_opentracing_cpp_ubuntu_18.04_0_2_1`](https://github.com/DataDog/docker-library/tree/master/dd-opentracing-cpp/ubuntu_18.04/0.2.1): Base image for CircleCI build of C++ OpenTracing integration (Ubuntu 18.04)

--- a/chef-kitchen/systemd/opensuse/Dockerfile
+++ b/chef-kitchen/systemd/opensuse/Dockerfile
@@ -1,0 +1,17 @@
+FROM opensuse/leap:15
+MAINTAINER Pablo Baeyens <pablo.baeyens@datadoghq.com>
+
+RUN zypper install -y \
+    openssh \
+    python=2.7.17 \
+    ruby=2.5
+
+# This is using the multistage docker build as described here:
+# https://docs.docker.com/develop/develop-images/multistage-build/
+
+# the temporary docker-library:chef_kitchen_systemd_scripts_0.1 is described in this repository
+COPY --from=datadog/docker-library:chef_kitchen_systemd_scripts_0.1 /usr/bin/systemctl /usr/bin/systemctl
+COPY --from=datadog/docker-library:chef_kitchen_systemd_scripts_0.1 /usr/bin/systemctl /usr/bin/systemd
+COPY --from=datadog/docker-library:chef_kitchen_systemd_scripts_0.1 /root/start.sh /root/start.sh
+
+CMD [ "/root/start.sh" ]


### PR DESCRIPTION
### What does this PR do?

Add a new OpenSUSE image with a fake systemd for kitchen docker tests on CircleCI.

### Motivation

The puppet datadog agent role tests the role against OpenSUSE Leap.