### PR TITLE
use `--no-cache-dir` flag to `pip` in dockerfiles to save space

### DIFF
--- a/ansible/2.4/centos/Dockerfile
+++ b/ansible/2.4/centos/Dockerfile
@@ -5,4 +5,4 @@ RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py \
     && rm get-pip.py
 
 # install latest 2.4 (ansible==2.4 will install 2.4.0 and not 2.4.4)
-RUN pip install "ansible>=2.4,<2.5"
+RUN pip install --no-cache-dir "ansible>=2.4,<2.5"

--- a/ansible/2.4/debian/Dockerfile
+++ b/ansible/2.4/debian/Dockerfile
@@ -9,4 +9,4 @@ RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py \
     && rm get-pip.py
 
 # install latest 2.4 (ansible==2.4 will install 2.4.0 and not 2.4.4)
-RUN pip install "ansible>=2.4,<2.5"
+RUN pip install --no-cache-dir "ansible>=2.4,<2.5"

--- a/ansible/2.5/centos/Dockerfile
+++ b/ansible/2.5/centos/Dockerfile
@@ -5,4 +5,4 @@ RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py \
     && rm get-pip.py
 
 # install latest 2.5 (ansible==2.5 will install 2.5.0 and not 2.5.5)
-RUN pip install "ansible>=2.5,<2.6"
+RUN pip install --no-cache-dir "ansible>=2.5,<2.6"

--- a/ansible/2.5/debian/Dockerfile
+++ b/ansible/2.5/debian/Dockerfile
@@ -9,4 +9,4 @@ RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py \
     && rm get-pip.py
 
 # install latest 2.5 (ansible==2.5 will install 2.5.0 and not 2.5.5)
-RUN pip install "ansible>=2.5,<2.6"
+RUN pip install --no-cache-dir "ansible>=2.5,<2.6"

--- a/ansible/2.6/centos/Dockerfile
+++ b/ansible/2.6/centos/Dockerfile
@@ -5,4 +5,4 @@ RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py \
     && rm get-pip.py
 
 # install latest 2.6 (ansible==2.6 will install 2.6.0 and not the latest 2.6.X)
-RUN pip install "ansible>=2.6,<2.7"
+RUN pip install --no-cache-dir "ansible>=2.6,<2.7"

--- a/ansible/2.6/debian/Dockerfile
+++ b/ansible/2.6/debian/Dockerfile
@@ -9,4 +9,4 @@ RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py \
     && rm get-pip.py
 
 # install latest 2.6 (ansible==2.6 will install 2.6.0 and not the latest 2.6.X)
-RUN pip install "ansible>=2.6,<2.7"
+RUN pip install --no-cache-dir "ansible>=2.6,<2.7"

--- a/ansible/2.7/centos/Dockerfile
+++ b/ansible/2.7/centos/Dockerfile
@@ -5,4 +5,4 @@ RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py \
     && rm get-pip.py
 
 # install latest 2.7 (ansible==2.7 will install 2.7.0 and not the latest 2.7.X)
-RUN pip install "ansible>=2.7,<2.8"
+RUN pip install --no-cache-dir "ansible>=2.7,<2.8"

--- a/ansible/2.7/debian/Dockerfile
+++ b/ansible/2.7/debian/Dockerfile
@@ -9,4 +9,4 @@ RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py \
     && rm get-pip.py
 
 # install latest 2.7 (ansible==2.7 will install 2.7.0 and not the latest 2.7.X)
-RUN pip install "ansible>=2.7,<2.8"
+RUN pip install --no-cache-dir "ansible>=2.7,<2.8"

--- a/ansible/2.8/centos/Dockerfile
+++ b/ansible/2.8/centos/Dockerfile
@@ -5,4 +5,4 @@ RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py \
     && rm get-pip.py
 
 # install latest 2.8 (ansible==2.8 will install 2.8.0 and not the latest 2.6.8)
-RUN pip install "ansible>=2.8,<2.9"
+RUN pip install --no-cache-dir "ansible>=2.8,<2.9"

--- a/ansible/2.8/debian/Dockerfile
+++ b/ansible/2.8/debian/Dockerfile
@@ -9,4 +9,4 @@ RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py \
     && rm get-pip.py
 
 # install latest 2.8 (ansible==2.8 will install 2.8.0 and not the latest 2.6.8)
-RUN pip install "ansible>=2.8,<2.9"
+RUN pip install --no-cache-dir "ansible>=2.8,<2.9"

--- a/dd-trace-php/alpine_building_testing_debugging/Dockerfile
+++ b/dd-trace-php/alpine_building_testing_debugging/Dockerfile
@@ -64,7 +64,7 @@ RUN set -ex \
 	&& (docker version || true); \
 # install docker-compose\
 	apk add --no-cache --virtual .persistent-docker-compose python3; \
-	pip3 install docker-compose; \
+	pip install --no-cache-dir docker-compose; \
 	docker-compose --version; \
 # install dockerize\
 	DOCKERIZE_URL="https://circle-downloads.s3.amazonaws.com/circleci-images/cache/linux-amd64/dockerize-latest.tar.gz" \

--- a/dd-trace-py/Dockerfile
+++ b/dd-trace-py/Dockerfile
@@ -62,11 +62,11 @@ RUN \
   && pyenv install 3.8.1 \
   && pyenv install 3.9-dev \
   && pyenv global 2.7.17 3.4.9 3.5.9 3.6.9 3.7.6 3.8.1 3.9-dev \
-  && pip install --upgrade pip
+  && pip install --no-cache-dir --upgrade pip
 
 # Install Python dependencies
 # DEV: `tox==3.7` introduced parallel execution mode
 #      https://tox.readthedocs.io/en/3.7.0/example/basic.html#parallel-mode
-RUN pip install "tox>=3.7,<4.0"
+RUN pip install --no-cache-dir "tox>=3.7,<4.0"
 
 CMD ["/bin/bash"]

--- a/snmp/Dockerfile
+++ b/snmp/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update \
 RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py \
     && python get-pip.py \
     && rm get-pip.py
-RUN pip install snmpsim
+RUN pip install --no-cache-dir snmpsim
 RUN groupadd snmpsim && useradd snmpsim -g snmpsim
 
 VOLUME /usr/snmpsim/data

--- a/supervisord/3.3.3/Dockerfile
+++ b/supervisord/3.3.3/Dockerfile
@@ -5,7 +5,7 @@ COPY program_0.sh /
 COPY program_1.sh /
 COPY program_2.sh /
 
-RUN pip install supervisor==3.3.3 &&chmod a+x /program_*.sh && mkdir supervisor
+RUN pip install --no-cache-dir supervisor==3.3.3 &&chmod a+x /program_*.sh && mkdir supervisor
 
 EXPOSE 19001
 


### PR DESCRIPTION
using "--no-cache-dir" flag in pip install ,make sure downloaded packages
by pip don't cached on system . This is a best practice which make sure
to fetch from repo instead of using local cached one . Further , in case
of Docker Containers , by restricting caching , we can reduce image size.
In term of stats , it depends upon the number of python packages
multiplied by their respective size . e.g for heavy packages with a lot
of dependencies it reduce a lot by don't caching pip packages.

Further , more detail information can be found at

https://medium.com/sciforce/strategies-of-docker-images-optimization-2ca9cc5719b6

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>