### PR TITLE
[ansible] Add Ansible 2.9 and 2.10 images

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Currently available tags:
 * [`ansible_2_6`](https://github.com/DataDog/docker-library/tree/master/ansible/2.6): Ansible v2.6
 * [`ansible_2_7`](https://github.com/DataDog/docker-library/tree/master/ansible/2.7): Ansible v2.7
 * [`ansible_2_8`](https://github.com/DataDog/docker-library/tree/master/ansible/2.8): Ansible v2.8
+* [`ansible_2_9`](https://github.com/DataDog/docker-library/tree/master/ansible/2.9): Ansible v2.9
+* [`ansible_2_10`](https://github.com/DataDog/docker-library/tree/master/ansible/2.10): Ansible v2.10
 * [`chef_kitchen_systemd_centos_6`](https://github.com/DataDog/docker-library/tree/master/chef-kitchen/systemd/centos6): Chef Kitchen image for testing systemd services on Centos 6
 * [`chef_kitchen_systemd_centos_7`](https://github.com/DataDog/docker-library/tree/master/chef-kitchen/systemd/centos7): Chef Kitchen image for testing systemd services on Centos 7
 * [`chef_kitchen_systemd_centos_8`](https://github.com/DataDog/docker-library/tree/master/chef-kitchen/systemd/centos8): Chef Kitchen image for testing systemd services on Centos 8

--- a/ansible/2.10/centos/Dockerfile
+++ b/ansible/2.10/centos/Dockerfile
@@ -1,0 +1,16 @@
+FROM centos:7
+
+RUN yum install -y python3
+
+RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py \
+    && python3 get-pip.py \
+    && rm get-pip.py
+
+# install latest 2.10
+RUN python3 -m pip install "ansible==2.10.*"
+
+# There's a systemctl binary in the image that doesn't seem to work
+# correctly (it only returns "Failed to get D-Bus connection: Operation not permitted")
+# Since Ansible 2.10, it gets picked up by Ansible, which tries to use it.
+# We remove this binary to prevent the CI from failing because of it.
+RUN rm -f /usr/bin/systemctl

--- a/ansible/2.10/debian/Dockerfile
+++ b/ansible/2.10/debian/Dockerfile
@@ -1,0 +1,12 @@
+FROM debian:buster-slim
+
+RUN apt-get update \
+    && apt-get install -y curl python3 gpg procps python3-apt python3-distutils \
+    && apt-get clean
+
+RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py \
+    && python3 get-pip.py \
+    && rm get-pip.py
+
+# install latest 2.10
+RUN python3 -m pip install "ansible==2.10.*"

--- a/ansible/2.9/centos/Dockerfile
+++ b/ansible/2.9/centos/Dockerfile
@@ -1,0 +1,10 @@
+FROM centos:7
+
+RUN yum install -y python3
+
+RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py \
+    && python3 get-pip.py \
+    && rm get-pip.py
+
+# install latest 2.9
+RUN python3 -m pip install "ansible==2.9.*"

--- a/ansible/2.9/debian/Dockerfile
+++ b/ansible/2.9/debian/Dockerfile
@@ -1,0 +1,12 @@
+FROM debian:buster-slim
+
+RUN apt-get update \
+    && apt-get install -y curl python3 gpg procps python3-apt python3-distutils \
+    && apt-get clean
+
+RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py \
+    && python3 get-pip.py \
+    && rm get-pip.py
+
+# install latest 2.9
+RUN python3 -m pip install "ansible==2.9.*"


### PR DESCRIPTION
### What does this PR do?

Adds images for the ansible-datadog CI, with Ansible 2.9 and Ansible 2.10, running on Python 3.