### PR TITLE
Add image for VoltDB 10.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Currently available tags:
 * [`supervisord_3_3_0`](https://github.com/DataDog/docker-library/tree/master/supervisord/3.3.0): Supervisord v.3.3.0
 * [`varnish_4_1_7`](https://github.com/DataDog/docker-library/tree/master/varnish/4.1.7): Varnish v.4.1.7
 * [`varnish_5_0_0`](https://github.com/DataDog/docker-library/tree/master/varnish/5.0.0): Varnish v.5.0.0
+* [`voltdb_10_0`](https://github.com/DataDog/docker-library/tree/master/voltdb/10.0): VoltDB v10.0 (Developer Edition)
 
 Middle stage image:
 

--- a/voltdb/10.0/Dockerfile
+++ b/voltdb/10.0/Dockerfile
@@ -1,0 +1,108 @@
+# NOTE(@florimondmanca) Inspired from:
+# https://github.com/VoltDB/voltdb/blob/voltdb-9.3.2/tools/docker/
+
+# NOTE(@florimondmanca): `voltdb` requires Python 2, which is why we stick to this older Ubuntu that has Python 2 by default.
+FROM ubuntu:14.04
+
+############################################################################################
+# This file is part of VoltDB.
+# Copyright (C) 2008-2020 VoltDB Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with VoltDB.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Docker file for building docker image given the kit bundle. Docker file uses
+# ubtuntu14.04 as base environment.
+#
+# Customizable docker properties for build and run time:
+#
+# Environment variables used at build times that can be passed in using --build-arg at build time
+# to package specific version of voltdb kit in docker image
+# VOLT_KIT_VERSION  Optional    Specifies the VoltDB kit - kit version suffix of voltdb in
+#                               "voltdb-<kit suffix>.tar.gz".
+#                               For eg. for voltdb-6.6.tar.gz, suffix will be 6.6.
+#                                       for voltdb-6.6rc1.tar.gz, suffix will be 6.6rc1.
+#                               If none, provided docker files uses value of is 6.6 which means
+#                               it's expecting file called voltdb-6.6.tar.gz file to package
+#                               voltdb docker image
+# VOLT_DIR_SUFFIX   Optional    Specifies the VoltDB kit directory after extracting the compressed
+#                               bundle file - "voltdb-<kit suffix>". For eg, voltdb-6.6.tar gets
+#                               extracted to voltdb-6.6 directory, so the directoy suffix is 6.6
+#
+# Run times customizable behavior using environment variables and mount points. Current docker image
+# is designed to run as executable performing "voltdb init" to initialize the cluster node and "voltdb
+# start" to start initialized database, by exceuting shell script through entrypoint
+#
+# Customize behavior for "voltdb init"
+# 1 - Deployment file to initialize with: The image gets packaged with default deployment which
+#     runs 2 site per host with k-factor of zero. The default deployment can be over-ridden by
+#     mounting custom deployment to file /tmp/deployment.xml in container using "-v <custom
+#     deployment's absolute path>:/tmp/deployment.xml"
+# 2 - Persist data in voltdbroot to host: Mount host location, which will be used as storage for
+#     voltdbroot to container path /var/voltdb/ using "-v <host storage location>:/var/voltdb/"
+#
+# Customize behavior for "voltdb start"
+# 1 - Host count needs to be passed in using HOST_COUNT docker environment through
+#     "-e HOST_COUNT=<# of nodes>"
+# 2 - Hosts list needs to be passed in using HOSTS docker environment through "-e HOSTS=<Comma
+#     separated hostnames or IP address>"
+#
+############################################################################################
+
+RUN set -e
+
+# Install VoltDB
+# update repo - Trusty does not seem to have add-repo command by default
+RUN DEBIAN_FRONTEND=noninteractive apt-get update \
+    && apt-get upgrade -y \
+    && apt-get -y  --no-install-recommends --no-install-suggests install python-software-properties \
+    && apt-get -y  --no-install-recommends --no-install-suggests install software-properties-common
+
+RUN add-apt-repository -y ppa:openjdk-r/ppa \
+    && apt-get update \
+    && apt-get install -y  --no-install-recommends --no-install-suggests openjdk-8-jdk wget
+
+# Expose the following ports
+# SSH                              22
+# Internal Server Port           3021
+# Replication Port               5555
+# Zookeeper port                 7181
+# Web Interface Port (httpd)     8080
+# Client Port                   21212
+# Admin Port                    21211
+EXPOSE 22 3021 5555 7181 8080 8081 9000 21211 21212
+
+ENV VOLTDB_DIST=/opt/voltdb
+ENV PATH=$PATH:$VOLTDB_DIST/bin
+
+RUN wget -O voltdb-developer-10.0.tar.gz "https://ddintegrations.blob.core.windows.net/voltdb/voltdb-developer-10.0.tar.gz"
+
+RUN tar -zxvf voltdb-developer-10.0.tar.gz \
+    && mkdir ${VOLTDB_DIST} \
+    && cp -r voltdb-developer-10.0/* $VOLTDB_DIST \
+    && rm -r voltdb-developer-10.0 voltdb-developer-10.0.tar.gz
+
+WORKDIR $VOLTDB_DIST
+
+COPY deployment.xml ${VOLTDB_DIST}
+ENV DEFAULT_DEPLOYMENT=$VOLTDB_DIST/deployment.xml
+ENV CUSTOM_CONFIG=/tmp/deployment.xml
+ENV LICENSE_FILE=/tmp/license.xml
+
+ENV DIRECTORY_SPEC=/var/voltdb/
+RUN mkdir $DIRECTORY_SPEC
+
+COPY docker-entrypoint.sh .
+RUN chmod +x docker-entrypoint.sh
+
+ENTRYPOINT ["./docker-entrypoint.sh"]

--- a/voltdb/10.0/deployment.xml
+++ b/voltdb/10.0/deployment.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<deployment>
+    <cluster sitesperhost="2" kfactor="0" />
+    <httpd enabled="true">
+        <jsonapi enabled="true" />
+    </httpd>
+</deployment>

--- a/voltdb/10.0/docker-entrypoint.sh
+++ b/voltdb/10.0/docker-entrypoint.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+############################################################################################
+# This file is part of VoltDB.
+# Copyright (C) 2008-2020 VoltDB Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with VoltDB.  If not, see <http://www.gnu.org/licenses/>.
+############################################################################################
+
+set -e
+
+function init() {
+    if [ -f  ${CUSTOM_CONFIG} ]; then
+        DEPLOYMENT=${CUSTOM_CONFIG}
+    else
+        DEPLOYMENT=${DEFAULT_DEPLOYMENT}
+    fi
+
+    INIT_OPTIONS="-C ${DEPLOYMENT} -D ${DIRECTORY_SPEC}"
+    echo "Run voltdb init $INIT_OPTIONS"
+    bin/voltdb init ${INIT_OPTIONS}
+}
+
+function execVoltdbStart() {
+    if [ -z "${HOST_COUNT}" ] && [ -z "${HOSTS}" ]; then
+        echo "To start a Volt cluster, atleast need to provide HOST_COUNT OR list of HOSTS"
+        exit
+    fi
+
+    if [ -n "${HOST_COUNT}" ]; then
+        OPTIONS=" -c $HOST_COUNT"
+    fi
+
+    if [ -n "${HOSTS}" ]; then
+        OPTIONS="$OPTIONS -H $HOSTS"
+    fi
+
+    if [ -n "${DIRECTORY_SPEC}" ]; then
+        OPTIONS="$OPTIONS -D ${DIRECTORY_SPEC}"
+    fi
+
+    if [ -f ${LICENSE_FILE} ]; then
+        OPTIONS="$OPTIONS -l ${LICENSE_FILE}"
+    fi
+
+    OPTIONS="$OPTIONS --ignore=thp"
+
+    echo "Run voltdb start $OPTIONS"
+    exec bin/voltdb start $OPTIONS
+}
+
+if [ ! -f ${DIRECTORY_SPEC}/voltdbroot/.initialized ]; then
+    init
+fi
+
+execVoltdbStart


### PR DESCRIPTION
Add a Dockerfile for VoltDB 10.0.

**Motivation**: we test integrations using Docker, but starting 10+ VoltDB doesn't provide community images anymore, so we built this for our own use in `integrations-core` testing.

**Note**: this image has already been pushed to DockerHub, and it is already being used successfully in https://github.com/DataDog/integrations-core/pull/7973.