### PR TITLE
[ansible] Update buster to bullseye, replace oldstable with stretch

### DIFF
--- a/ansible/2.10/debian/Dockerfile
+++ b/ansible/2.10/debian/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster-slim
+FROM debian:bullseye-slim
 
 RUN apt-get update \
     && apt-get install -y curl python3 gpg procps python3-apt python3-distutils \

--- a/ansible/2.6/debian/Dockerfile
+++ b/ansible/2.6/debian/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get update \
     && apt-get install -y curl python gpg procps python-apt \
     && apt-get clean
 
-RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py \
+RUN curl https://bootstrap.pypa.io/pip/2.7/get-pip.py -o get-pip.py \
     && python get-pip.py \
     && rm get-pip.py
 

--- a/ansible/2.6/debian/Dockerfile
+++ b/ansible/2.6/debian/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:oldstable-slim
+FROM debian:stretch-slim
 
 RUN apt-get update \
     && apt-get install -y curl python gpg procps python-apt \

--- a/ansible/2.7/debian/Dockerfile
+++ b/ansible/2.7/debian/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get update \
     && apt-get install -y curl python gpg procps python-apt \
     && apt-get clean
 
-RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py \
+RUN curl https://bootstrap.pypa.io/pip/2.7/get-pip.py -o get-pip.py \
     && python get-pip.py \
     && rm get-pip.py
 

--- a/ansible/2.7/debian/Dockerfile
+++ b/ansible/2.7/debian/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:oldstable-slim
+FROM debian:stretch-slim
 
 RUN apt-get update \
     && apt-get install -y curl python gpg procps python-apt \

--- a/ansible/2.8/debian/Dockerfile
+++ b/ansible/2.8/debian/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get update \
     && apt-get install -y curl python gpg procps python-apt \
     && apt-get clean
 
-RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py \
+RUN curl https://bootstrap.pypa.io/pip/2.7/get-pip.py -o get-pip.py \
     && python get-pip.py \
     && rm get-pip.py
 

--- a/ansible/2.8/debian/Dockerfile
+++ b/ansible/2.8/debian/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:oldstable-slim
+FROM debian:stretch-slim
 
 RUN apt-get update \
     && apt-get install -y curl python gpg procps python-apt \

--- a/ansible/2.9/debian/Dockerfile
+++ b/ansible/2.9/debian/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster-slim
+FROM debian:bullseye-slim
 
 RUN apt-get update \
     && apt-get install -y curl python3 gpg procps python3-apt python3-distutils \


### PR DESCRIPTION
* The 2.6, 2.7 and 2.8 are now pinned to stretch. This is because ansible-datadog CI needs them to have Python 2 installed https://github.com/DataDog/ansible-datadog/blob/master/.circleci/config.yml#L137
* The 2.9 and 2.10 are now moved to the newly released bullseye