### PR TITLE
add sqlserver windows containers for versions 2016, 2017, 2019

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,9 @@ Currently available tags:
 * [`powerdns_recursor_4_0_9`](https://github.com/DataDog/docker-library/tree/master/powerdns\_recursor/4.0.9): Powerdns Recursor v.4.0.9
 * [`snmp`](https://github.com/DataDog/docker-library/tree/master/snmp): Image for SNMP testing with [snmpsim](http://snmplabs.com/snmpsim/quickstart.html)
 * [`supervisord_3_3_0`](https://github.com/DataDog/docker-library/tree/master/supervisord/3.3.0): Supervisord v.3.3.0
+* [`sqlserver_2019`](https://github.com/DataDog/docker-library/tree/master/sqlserver/windows/Dockerfile_2019): Microsoft SQL Server 2019
+* [`sqlserver_2017`](https://github.com/DataDog/docker-library/tree/master/sqlserver/windows/Dockerfile_2017): Microsoft SQL Server 2017
+* [`sqlserver_2016`](https://github.com/DataDog/docker-library/tree/master/sqlserver/windows/Dockerfile_2016): Microsoft SQL Server 2016
 * [`varnish_4_1_7`](https://github.com/DataDog/docker-library/tree/master/varnish/4.1.7): Varnish v.4.1.7
 * [`varnish_5_0_0`](https://github.com/DataDog/docker-library/tree/master/varnish/5.0.0): Varnish v.5.0.0
 * [`voltdb_10_0`](https://github.com/DataDog/docker-library/tree/master/voltdb/10.0): VoltDB v10.0 (Developer Edition)

--- a/sqlserver/windows/Dockerfile_2016
+++ b/sqlserver/windows/Dockerfile_2016
@@ -1,0 +1,4 @@
+FROM mcr.microsoft.com/windows/servercore:ltsc2019
+
+RUN curl "https://go.microsoft.com/fwlink/?LinkID=799011" -L -o sqlserver-install.exe
+RUN .\sqlserver-install.exe /ACTION="install" /IACCEPTSQLSERVERLICENSETERMS /QUIET /VERBOSE

--- a/sqlserver/windows/Dockerfile_2016
+++ b/sqlserver/windows/Dockerfile_2016
@@ -2,3 +2,5 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2019
 
 RUN curl "https://go.microsoft.com/fwlink/?LinkID=799011" -L -o sqlserver-install.exe
 RUN .\sqlserver-install.exe /ACTION="install" /IACCEPTSQLSERVERLICENSETERMS /QUIET /VERBOSE
+
+CMD ping -t localhost > NUL

--- a/sqlserver/windows/Dockerfile_2017
+++ b/sqlserver/windows/Dockerfile_2017
@@ -1,0 +1,4 @@
+FROM mcr.microsoft.com/windows/servercore:ltsc2019
+
+RUN curl "https://go.microsoft.com/fwlink/?LinkID=853015" -L -o sqlserver-install.exe
+RUN .\sqlserver-install.exe /ACTION="install" /IACCEPTSQLSERVERLICENSETERMS /QUIET /VERBOSE

--- a/sqlserver/windows/Dockerfile_2017
+++ b/sqlserver/windows/Dockerfile_2017
@@ -2,3 +2,5 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2019
 
 RUN curl "https://go.microsoft.com/fwlink/?LinkID=853015" -L -o sqlserver-install.exe
 RUN .\sqlserver-install.exe /ACTION="install" /IACCEPTSQLSERVERLICENSETERMS /QUIET /VERBOSE
+
+CMD ping -t localhost > NUL

--- a/sqlserver/windows/Dockerfile_2019
+++ b/sqlserver/windows/Dockerfile_2019
@@ -2,3 +2,5 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2019
 
 RUN curl "https://go.microsoft.com/fwlink/?LinkID=866662" -L -o sqlserver-install.exe
 RUN .\sqlserver-install.exe /ACTION="install" /IACCEPTSQLSERVERLICENSETERMS /QUIET /VERBOSE
+
+CMD ping -t localhost > NUL

--- a/sqlserver/windows/Dockerfile_2019
+++ b/sqlserver/windows/Dockerfile_2019
@@ -1,0 +1,4 @@
+FROM mcr.microsoft.com/windows/servercore:ltsc2019
+
+RUN curl "https://go.microsoft.com/fwlink/?LinkID=866662" -L -o sqlserver-install.exe
+RUN .\sqlserver-install.exe /ACTION="install" /IACCEPTSQLSERVERLICENSETERMS /QUIET /VERBOSE

--- a/sqlserver/windows/README.md
+++ b/sqlserver/windows/README.md
@@ -1,0 +1,23 @@
+
+# SQL Server Windows Containers
+
+[Microsoft SQL Server](https://www.microsoft.com/en-us/sql-server/sql-server-downloads) installed into a [Windows Server Core](https://hub.docker.com/_/microsoft-windows-servercore) Container.
+
+# Versions
+
+## SQL Server 2019
+
+```
+docker build -t datadog/docker-library:sqlserver_2019 -f Dockerfile_2019
+```
+
+## SQL Server 2017
+```
+docker build -t datadog/docker-library:sqlserver_2017 -f Dockerfile_2017
+```
+
+## SQL Server 2016
+
+```
+docker build -t datadog/docker-library:sqlserver_2016 -f Dockerfile_2016
+```

--- a/sqlserver/windows/README.md
+++ b/sqlserver/windows/README.md
@@ -8,16 +8,16 @@
 ## SQL Server 2019
 
 ```
-docker build -t datadog/docker-library:sqlserver_2019 -f Dockerfile_2019
+docker build -t datadog/docker-library:sqlserver_2019 -f Dockerfile_2019 .
 ```
 
 ## SQL Server 2017
 ```
-docker build -t datadog/docker-library:sqlserver_2017 -f Dockerfile_2017
+docker build -t datadog/docker-library:sqlserver_2017 -f Dockerfile_2017 .
 ```
 
 ## SQL Server 2016
 
 ```
-docker build -t datadog/docker-library:sqlserver_2016 -f Dockerfile_2016
+docker build -t datadog/docker-library:sqlserver_2016 -f Dockerfile_2016 .
 ```


### PR DESCRIPTION
Add SQL Server windows containers for versions 2016, 2017, 2019. These will be used for windows integration tests for our SQL Server integration.