### PR TITLE
Change chef-kitchen Dockerfile maintainers to Agent Platform

### DIFF
--- a/chef-kitchen/systemd/amazonlinux2/Dockerfile
+++ b/chef-kitchen/systemd/amazonlinux2/Dockerfile
@@ -1,5 +1,5 @@
 FROM amazonlinux:2
-MAINTAINER Agent Platform <team-agent-platform@datadoghq.com>
+LABEL maintainer="Agent Platform <team-agent-platform@datadoghq.com>"
 
 RUN yum install -y openssh-server openssh-clients
 

--- a/chef-kitchen/systemd/amazonlinux2/Dockerfile
+++ b/chef-kitchen/systemd/amazonlinux2/Dockerfile
@@ -1,5 +1,5 @@
 FROM amazonlinux:2
-LABEL maintainer="julien.lebot@datadoghq.com"
+MAINTAINER Agent Platform <team-agent-platform@datadoghq.com>
 
 RUN yum install -y openssh-server openssh-clients
 

--- a/chef-kitchen/systemd/centos6/Dockerfile
+++ b/chef-kitchen/systemd/centos6/Dockerfile
@@ -1,5 +1,5 @@
 FROM centos:6
-MAINTAINER Agent Platform <team-agent-platform@datadoghq.com>
+LABEL maintainer="Agent Platform <team-agent-platform@datadoghq.com>"
 
 # Enable the vault (archive) repos, as we are past CentOS6 EOL
 RUN sed -is 's/enabled=0/enabled=1/g' /etc/yum.repos.d/CentOS-Vault.repo && \

--- a/chef-kitchen/systemd/centos7/Dockerfile
+++ b/chef-kitchen/systemd/centos7/Dockerfile
@@ -1,5 +1,5 @@
 FROM centos:7
-MAINTAINER Agent Platform <team-agent-platform@datadoghq.com>
+LABEL maintainer="Agent Platform <team-agent-platform@datadoghq.com>"
 
 RUN yum install -y epel-release
 RUN yum search openssh

--- a/chef-kitchen/systemd/centos7/Dockerfile
+++ b/chef-kitchen/systemd/centos7/Dockerfile
@@ -1,5 +1,5 @@
 FROM centos:7
-MAINTAINER Karim Bogtob <karim.bogtob@datadoghq.com>
+MAINTAINER Agent Platform <team-agent-platform@datadoghq.com>
 
 RUN yum install -y epel-release
 RUN yum search openssh

--- a/chef-kitchen/systemd/centos8/Dockerfile
+++ b/chef-kitchen/systemd/centos8/Dockerfile
@@ -1,5 +1,5 @@
 FROM centos:8
-MAINTAINER Karim Bogtob <karim.bogtob@datadoghq.com>
+MAINTAINER Agent Platform <team-agent-platform@datadoghq.com>
 
 RUN yum install -y epel-release
 RUN yum search openssh

--- a/chef-kitchen/systemd/centos8/Dockerfile
+++ b/chef-kitchen/systemd/centos8/Dockerfile
@@ -1,5 +1,5 @@
 FROM centos:8
-MAINTAINER Agent Platform <team-agent-platform@datadoghq.com>
+LABEL maintainer="Agent Platform <team-agent-platform@datadoghq.com>"
 
 RUN yum install -y epel-release
 RUN yum search openssh

--- a/chef-kitchen/systemd/opensuse/Dockerfile
+++ b/chef-kitchen/systemd/opensuse/Dockerfile
@@ -1,5 +1,5 @@
 FROM opensuse/leap:15
-MAINTAINER Agent Platform <team-agent-platform@datadoghq.com>
+LABEL maintainer="Agent Platform <team-agent-platform@datadoghq.com>"
 
 RUN zypper install -y \
     openssh \

--- a/chef-kitchen/systemd/opensuse/Dockerfile
+++ b/chef-kitchen/systemd/opensuse/Dockerfile
@@ -1,5 +1,5 @@
 FROM opensuse/leap:15
-MAINTAINER Pablo Baeyens <pablo.baeyens@datadoghq.com>
+MAINTAINER Agent Platform <team-agent-platform@datadoghq.com>
 
 RUN zypper install -y \
     openssh \

--- a/chef-kitchen/systemd/rocky8/Dockerfile
+++ b/chef-kitchen/systemd/rocky8/Dockerfile
@@ -1,4 +1,5 @@
 FROM rockylinux:8
+MAINTAINER Agent Platform <team-agent-platform@datadoghq.com>
 
 RUN yum install -y epel-release
 RUN yum install -y openssh-server openssh-clients python2-2.7.*

--- a/chef-kitchen/systemd/rocky8/Dockerfile
+++ b/chef-kitchen/systemd/rocky8/Dockerfile
@@ -1,5 +1,5 @@
 FROM rockylinux:8
-MAINTAINER Agent Platform <team-agent-platform@datadoghq.com>
+LABEL maintainer="Agent Platform <team-agent-platform@datadoghq.com>"
 
 RUN yum install -y epel-release
 RUN yum install -y openssh-server openssh-clients python2-2.7.*

--- a/chef-kitchen/systemd/scripts/0.1/Dockerfile
+++ b/chef-kitchen/systemd/scripts/0.1/Dockerfile
@@ -1,5 +1,5 @@
 FROM scratch
-MAINTAINER Agent Platform <team-agent-platform@datadoghq.com>
+LABEL maintainer="Agent Platform <team-agent-platform@datadoghq.com>"
 
 # The goal of this image is to be useful as a multistage docker image build
 COPY systemctl.py /usr/bin/systemctl

--- a/chef-kitchen/systemd/scripts/0.1/Dockerfile
+++ b/chef-kitchen/systemd/scripts/0.1/Dockerfile
@@ -1,5 +1,5 @@
 FROM scratch
-MAINTAINER Karim Bogtob <karim.bogtob@datadoghq.com>
+MAINTAINER Agent Platform <team-agent-platform@datadoghq.com>
 
 # The goal of this image is to be useful as a multistage docker image build
 COPY systemctl.py /usr/bin/systemctl


### PR DESCRIPTION
This PR changes every chef-kitchen Dockerfile maintainers to `Agent Platform <team-agent-platform@datadoghq.com>` because it makes more sense today.