### PR TITLE
Debian 8 (Jessie) image GPG key workaround for apt

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Currently available tags:
 * [`ansible_2_9`](https://github.com/DataDog/docker-library/tree/master/ansible/2.9): Ansible v2.9
 * [`ansible_2_10`](https://github.com/DataDog/docker-library/tree/master/ansible/2.10): Ansible v2.10
 * [`cacti-1.2.19`](https://github.com/DataDog/docker-library/tree/master/cacti/1.2.19): Cacti v1.2.19
+* [`chef_kitchen_apt_debian_8`](https://github.com/DataDog/docker-library/tree/master/chef-kitchen/apt/debian8): Chef Kitchen image for testing debian 8.
 * [`chef_kitchen_systemd_centos_6`](https://github.com/DataDog/docker-library/tree/master/chef-kitchen/systemd/centos6): Chef Kitchen image for testing systemd services on Centos 6
 * [`chef_kitchen_systemd_centos_7`](https://github.com/DataDog/docker-library/tree/master/chef-kitchen/systemd/centos7): Chef Kitchen image for testing systemd services on Centos 7
 * [`chef_kitchen_systemd_centos_8`](https://github.com/DataDog/docker-library/tree/master/chef-kitchen/systemd/centos8): Chef Kitchen image for testing systemd services on Centos 8

--- a/chef-kitchen/apt/debian8/Dockerfile
+++ b/chef-kitchen/apt/debian8/Dockerfile
@@ -1,5 +1,5 @@
 FROM debian:8
-MAINTAINER Agent Platform <team-agent-platform@datadoghq.com>
+LABEL maintainer="Agent Platform <team-agent-platform@datadoghq.com>"
 
 # The Debian Jessie GPG key expired on Sat Nov 19 2022 21:01:13 GMT+0000.
 # Use gpgv wrapper that ignores key expiration date but checks package signatures.

--- a/chef-kitchen/apt/debian8/Dockerfile
+++ b/chef-kitchen/apt/debian8/Dockerfile
@@ -1,0 +1,7 @@
+FROM debian:8
+MAINTAINER Agent Platform <team-agent-platform@datadoghq.com>
+
+# The Debian Jessie GPG key expired on Sat Nov 19 2022 21:01:13 GMT+0000.
+# Use gpgv wrapper that ignores key expiration date but checks package signatures.
+COPY gpgvnoexpkeysig /usr/local/sbin
+RUN echo 'Dir::Bin::gpg "/usr/local/sbin/gpgvnoexpkeysig";' >> /etc/apt/apt.conf.d/20datadog

--- a/chef-kitchen/apt/debian8/Dockerfile
+++ b/chef-kitchen/apt/debian8/Dockerfile
@@ -5,3 +5,5 @@ MAINTAINER Agent Platform <team-agent-platform@datadoghq.com>
 # Use gpgv wrapper that ignores key expiration date but checks package signatures.
 COPY gpgvnoexpkeysig /usr/local/sbin
 RUN echo 'Dir::Bin::gpg "/usr/local/sbin/gpgvnoexpkeysig";' >> /etc/apt/apt.conf.d/20datadog
+
+CMD [ "/root/start.sh" ]

--- a/chef-kitchen/apt/debian8/gpgvnoexpkeysig
+++ b/chef-kitchen/apt/debian8/gpgvnoexpkeysig
@@ -1,0 +1,54 @@
+#!/bin/sh
+#
+# This script is in the public domain
+#
+# Author: Johannes Schauer Marin Rodrigues <josch@mister-muffin.de>
+#
+# This is a wrapper around gpgv as invoked by apt. It turns EXPKEYSIG results
+# from gpgv into GOODSIG results. This is necessary for apt to access very old
+# timestamps from snapshot.debian.org for which the GPG key is already expired:
+#
+#     Get:1 http://snapshot.debian.org/archive/debian/20150106T000000Z unstable InRelease [242 kB]
+#     Err:1 http://snapshot.debian.org/archive/debian/20150106T000000Z unstable InRelease
+#       The following signatures were invalid: EXPKEYSIG 8B48AD6246925553 Debian Archive Automatic Signing Key (7.0/wheezy) <ftpmaster@debian.org>
+#     Reading package lists...
+#     W: GPG error: http://snapshot.debian.org/archive/debian/20150106T000000Z unstable InRelease: The following signatures were invalid: EXPKEYSIG 8B48AD6246925553 Debian Archive Automatic Signing Key (7.0/wheezy) <ftpmaster@debian.org>
+#     E: The repository 'http://snapshot.debian.org/archive/debian/20150106T000000Z unstable InRelease' is not signed.
+#
+# How to use this script depends on the APT version, in particular of whether your version has this patch https://salsa.debian.org/apt-team/apt/-/commit/12841e8320aa499554ac50b102b222900bb1b879:
+#
+# 1. On apt 1.0 or lower, call apt with
+#    -o Apt::Key::gpgvcommand=/usr/libexec/mmdebstrap/gpgvnoexpkeysig
+#
+# 2. On apt 1.1 or higher, call apt with
+#    -o Dir::Bin::gpg=/usr/libexec/mmdebstrap/gpgvnoexpkeysig
+#
+# Scripts doing similar things can be found here:
+#
+#  * debuerreotype as /usr/share/debuerreotype/scripts/.gpgv-ignore-expiration.sh
+#  * derivative census: salsa.d.o/deriv-team/census/-/blob/master/bin/fakegpgv
+
+set -eu
+
+find_gpgv_status_fd() {
+	while [ "$#" -gt 0 ]; do
+		if [ "$1" = '--status-fd' ]; then
+			echo "$2"
+			return 0
+		fi
+		shift
+	done
+	# default fd is stdout
+	echo 1
+}
+GPGSTATUSFD="$(find_gpgv_status_fd "$@")"
+
+case $GPGSTATUSFD in
+	''|*[!0-9]*)
+		echo "invalid --status-fd argument" >&2
+		exit 1
+		;;
+esac
+
+# we need eval because we cannot redirect a variable fd
+eval 'exec gpgv "$@" '"$GPGSTATUSFD"'>&1 | sed "s/^\[GNUPG:\] EXPKEYSIG /[GNUPG:] GOODSIG /" >&'"$GPGSTATUSFD"


### PR DESCRIPTION
The Debian Jessie GPG key expired on Sat Nov 19 2022 21:01:13 GMT+0000. This PR uses gpgv wrapper that ignores key expiration date but checks package signatures such as [this PR](https://github.com/DataDog/datadog-agent-buildimages/pull/319).