### PR TITLE
Add docker file for sqlserver on windows 22 image

### DIFF
--- a/sqlserver/windows/Dockerfile_2022
+++ b/sqlserver/windows/Dockerfile_2022
@@ -1,0 +1,6 @@
+FROM mcr.microsoft.com/windows/servercore:ltsc2022
+
+RUN curl "https://go.microsoft.com/fwlink/?LinkID=866662" -L -o sqlserver-install.exe
+RUN .\sqlserver-install.exe /ACTION="install" /IACCEPTSQLSERVERLICENSETERMS /QUIET /VERBOSE
+
+CMD ping -t localhost > NUL


### PR DESCRIPTION
Needed to run sqlserver tests on windows 22, which is part of the effort to migrate sqlserver integrations CI from azure pipelines to github actions