### PR TITLE
[ansible] Update Debian stretch repos to use Debian Archive

### DIFF
--- a/ansible/2.6/debian/Dockerfile
+++ b/ansible/2.6/debian/Dockerfile
@@ -1,5 +1,7 @@
 FROM debian:stretch-slim
 
+RUN printf 'deb http://archive.debian.org/debian stretch main\ndeb http://archive.debian.org/debian-security stretch/updates main' > /etc/apt/sources.list
+
 RUN apt-get update \
     && apt-get install -y curl python gpg procps python-apt \
     && apt-get clean

--- a/ansible/2.7/debian/Dockerfile
+++ b/ansible/2.7/debian/Dockerfile
@@ -1,5 +1,7 @@
 FROM debian:stretch-slim
 
+RUN printf 'deb http://archive.debian.org/debian stretch main\ndeb http://archive.debian.org/debian-security stretch/updates main' > /etc/apt/sources.list
+
 RUN apt-get update \
     && apt-get install -y curl python gpg procps python-apt \
     && apt-get clean

--- a/ansible/2.8/debian/Dockerfile
+++ b/ansible/2.8/debian/Dockerfile
@@ -1,5 +1,7 @@
 FROM debian:stretch-slim
 
+RUN printf 'deb http://archive.debian.org/debian stretch main\ndeb http://archive.debian.org/debian-security stretch/updates main' > /etc/apt/sources.list
+
 RUN apt-get update \
     && apt-get install -y curl python gpg procps python-apt \
     && apt-get clean


### PR DESCRIPTION
Debian Stretch packages are now only available in the Debian Archive, so point our older image repos there.