### PR TITLE
add `jq` and remove `rpmlint` which is not used

### DIFF
--- a/dd-trace-php/Dockerfile_fpm
+++ b/dd-trace-php/Dockerfile_fpm
@@ -4,7 +4,7 @@ USER root
 WORKDIR /home/circleci
 
 ADD fpm_apk_pax_header.patch /tmp
-RUN apt-get update && apt-get -y install vim less build-essential rpm rpmlint lintian\
+RUN apt-get update && apt-get -y install vim less build-essential rpm lintian jq\
     && gem install fpm -v 1.11.0\
     && (cd /usr/local/bundle/gems/fpm-1.11.0/; patch -p 1 < /tmp/fpm_apk_pax_header.patch )\
     && rm -f /tmp/fpm_apk_pax_header.patch


### PR DESCRIPTION
Updates an old image (4 years) that started to fall apart just over night by rebuilding and add `jq` to the image so we do not need to do this in CI every single time. `rpmlint` does not exists anymore in this Debian release but it seems we do not need it anyway

I pushed the resulting image already and have it in a feature branch at this PR https://github.com/DataDog/dd-trace-php/pull/2048

If everything is okay, I'll merge, create the image and push to the original tag.

Related to: https://github.com/DataDog/dd-trace-php/pull/2044