### PR TITLE
Update image to be able to fetch correctly packages

### DIFF
--- a/chef-kitchen/apt/debian8/Dockerfile
+++ b/chef-kitchen/apt/debian8/Dockerfile
@@ -5,3 +5,9 @@ LABEL maintainer="Agent Platform <team-agent-platform@datadoghq.com>"
 # Use gpgv wrapper that ignores key expiration date but checks package signatures.
 COPY gpgvnoexpkeysig /usr/local/sbin
 RUN echo 'Dir::Bin::gpg "/usr/local/sbin/gpgvnoexpkeysig";' >> /etc/apt/apt.conf.d/20datadog
+# Jessie is no more on mirror network, we must use archived sources
+RUN echo 'Acquire::Check-Valid-Until "false";' >> /etc/apt/apt.conf.d/99custom
+RUN rm /etc/apt/sources.list
+RUN echo "deb [check-valid-until=no] http://archive.debian.org/debian jessie-backports main" > /etc/apt/sources.list.d/jessie-backports.list
+RUN echo "deb [check-valid-until=no] http://archive.debian.org/debian-security jessie/updates main" >> /etc/apt/sources.list.d/jessie.list
+RUN echo "deb [check-valid-until=no] http://archive.debian.org/debian-archive/debian jessie main" >> /etc/apt/sources.list.d/jessie.list


### PR DESCRIPTION
Debian8 (Jessie) is out of support and some packages are not available anymore in standard package stores. This image is used in the kitchen test of https://github.com/DataDog/chef-datadog/ and apt-get update fails if we don't fetch packages from archive sources