### PR TITLE
Add tar to suse and al2 image to use it in Github Action

### DIFF
--- a/ansible/amazonlinux2/Dockerfile
+++ b/ansible/amazonlinux2/Dockerfile
@@ -9,7 +9,8 @@ ENV LANG en_US.UTF-8
 ENV LC_ALL en_US.UTF-8
 
 # Agent < 7.35 doesn't have "Requires(pre): shadow-utils"
-RUN yum install -y python3 shadow-utils
+# We install tar here to be able to use the image in Github Action (checkout requires tar)
+RUN yum install -y python3 shadow-utils tar
 
 RUN curl https://bootstrap.pypa.io/pip/get-pip.py -o get-pip.py \
     && python3 get-pip.py \

--- a/ansible/suse/Dockerfile
+++ b/ansible/suse/Dockerfile
@@ -3,8 +3,9 @@ FROM opensuse/leap:15.2
 ARG ANSIBLE_VERSION
 RUN test -n "$ANSIBLE_VERSION"
 
+# We install tar here to be able to use the image in Github Action (checkout requires tar)
 RUN zypper refresh \
-    && zypper install -y curl python3
+    && zypper install -y curl python3 tar
 
 RUN curl https://bootstrap.pypa.io/pip/3.6/get-pip.py -o get-pip.py \
     && python3 get-pip.py \


### PR DESCRIPTION
Add `tar` to the AL2 and Centos images, otherwise `action/checkout` fails in Github Actions