### PR TITLE
Add git and openssh-client as required in circleci for basic checkout

### DIFF
--- a/ansible/debian/Dockerfile
+++ b/ansible/debian/Dockerfile
@@ -4,7 +4,7 @@ ARG ANSIBLE_VERSION
 RUN test -n "$ANSIBLE_VERSION"
 
 RUN apt-get update \
-    && apt-get install -y curl python3 gpg procps python3-apt python3-distutils \
+    && apt-get install -y curl python3 gpg procps python3-apt python3-distutils git openssh-client\
     && apt-get clean
 
 RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py \


### PR DESCRIPTION
When trying to add [changes](https://github.com/DataDog/ansible-datadog/pull/515/files) in the ci_test done on ansible-datadog repo, I face [issues](https://app.circleci.com/pipelines/github/DataDog/ansible-datadog/840/workflows/4ff5cf0a-6441-458a-ad48-4056ca465e9c/jobs/63407) with circleci failing to retrieve git.
It seems [it's the case from the very beginning](https://app.circleci.com/pipelines/github/DataDog/ansible-datadog/838/workflows/a6046527-a118-44ac-b0c8-63db1868603d/jobs/63129?invite=true#step-101-0_177). Trying to add git and ssh to the image to have a coherent behaviour