### PR TITLE
build sqlserver 2022 on windows server 2019

### DIFF
--- a/sqlserver/windows/Dockerfile_2022
+++ b/sqlserver/windows/Dockerfile_2022
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/windows/servercore:ltsc2022
+FROM mcr.microsoft.com/windows/servercore:ltsc2019
 
 RUN curl "https://go.microsoft.com/fwlink/?LinkID=2215158" -L -o sqlserver-install.exe
 RUN .\sqlserver-install.exe /ACTION="install" /IACCEPTSQLSERVERLICENSETERMS /QUIET /VERBOSE

--- a/sqlserver/windows/README.md
+++ b/sqlserver/windows/README.md
@@ -5,6 +5,12 @@
 
 # Versions
 
+## SQL Server 2022
+
+```
+docker build -t datadog/docker-library:sqlserver_2022 -f Dockerfile_2022 .
+```
+
 ## SQL Server 2019
 
 ```


### PR DESCRIPTION
integrations-core/sqlserver tests run on windows-2019 runner. build sqlserver-2022 on windows server 2019 to avoid error 
`The container operating system does not match the host operating system`. 
According to Microsoft [doc](https://learn.microsoft.com/en-us/troubleshoot/sql/general/use-sql-server-in-windows), sqlserver 2022 is supported on windows 2019.