### PR TITLE
Allow newer ansible versions in some images by installing newer python

### DIFF
--- a/ansible/build.sh
+++ b/ansible/build.sh
@@ -19,5 +19,5 @@ echo "$ansible_major_minor" | grep '^\d\+\.\d\+$' > /dev/null || help
 ansible_underscored=$(echo "$ansible_major_minor" | sed "s|\.|_|")
 
 for distro in $(echo $distros | tr "," "\n"); do
-  docker build --tag "datadog/docker-library:ansible_${distro}_${ansible_underscored}" --build-arg ANSIBLE_VERSION="$ansible_major_minor" --file "$distro/Dockerfile" "$distro/"
+  docker build --tag "datadog/docker-library:ansible_${distro}_${ansible_underscored}" --build-arg ANSIBLE_VERSION="$ansible_major_minor" --file "$distro/Dockerfile" .
 done

--- a/ansible/build_python.sh
+++ b/ansible/build_python.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -euo pipefail
+
+ansible_major=$(printf "${ANSIBLE_VERSION}" | cut -f1 -d'.')
+
+# Decide on python version depending on Ansible major version
+if [[ "${ansible_major}" -ge 7 ]]; then
+    python_version=3.10.14
+else
+    python_version=3.8.19
+fi
+
+download_url="https://python.org/ftp/python/${python_version}/Python-${python_version}.tgz"
+relative_path="Python-${python_version}"
+archive_name="$(basename ${download_url})"
+workdir="/tmp/build-${archive_name}"
+mkdir -p "${workdir}"
+
+# Download and install Python
+curl "${download_url}" -L | tar -xzC "${workdir}" --
+pushd "${workdir}/${relative_path}"
+./configure --prefix="${ANSIBLE_PYTHON_PATH}" --with-ensurepip=yes --enable-ipv6
+make -j $(nproc)
+make install
+popd
+rm -rf "${workdir}"

--- a/ansible/debian/Dockerfile
+++ b/ansible/debian/Dockerfile
@@ -7,9 +7,12 @@ RUN apt-get update \
     && apt-get install -y curl python3 gpg procps python3-apt python3-distutils git openssh-client\
     && apt-get clean
 
-RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py \
-    && python3 get-pip.py \
-    && rm get-pip.py
-
-# install latest 2.10
-RUN python3 -m pip install "ansible==$ANSIBLE_VERSION.*"
+# Install necessary Python version for the controller and use that Python to install Ansible
+COPY build_python.sh /
+ENV ANSIBLE_PYTHON_PATH="/opt/ansible-python"
+RUN apt-get install -y build-essential libssl-dev zlib1g-dev \
+    libbz2-dev xz-utils libffi-dev liblzma-dev \
+    && bash build_python.sh
+RUN "$ANSIBLE_PYTHON_PATH/bin/python3" -m pip install "ansible==$ANSIBLE_VERSION.*" \
+    # We want the ansible executable to be in $PATH but without interfering with system python
+    && for f in $ANSIBLE_PYTHON_PATH/bin/ansible-*; do ln -s $f "/usr/bin/$(basename $f)"; done

--- a/ansible/rocky8/Dockerfile
+++ b/ansible/rocky8/Dockerfile
@@ -5,12 +5,14 @@ RUN test -n "$ANSIBLE_VERSION"
 
 RUN yum install -y python3
 
-RUN curl https://bootstrap.pypa.io/pip/3.6/get-pip.py -o get-pip.py \
-    && python3 get-pip.py \
-    && rm get-pip.py
-
-# install latest 2.10
-RUN python3 -m pip install "ansible==$ANSIBLE_VERSION.*"
+# Install necessary Python version for the controller and use that Python to install Ansible
+COPY build_python.sh /
+ENV ANSIBLE_PYTHON_PATH="/opt/ansible-python"
+RUN yum install -y gcc make patch zlib-devel bzip2 bzip2-devel openssl-devel libffi-devel xz-devel \
+    && bash build_python.sh
+RUN "$ANSIBLE_PYTHON_PATH/bin/python3" -m pip install "ansible==$ANSIBLE_VERSION.*" \
+    # We want the ansible executable to be in $PATH but without interfering with system python
+    && for f in $ANSIBLE_PYTHON_PATH/bin/ansible-*; do ln -s $f "/usr/bin/$(basename $f)"; done
 
 # Use the systemctl shim
 RUN rm -f /usr/bin/systemctl

--- a/ansible/suse/Dockerfile
+++ b/ansible/suse/Dockerfile
@@ -5,11 +5,14 @@ RUN test -n "$ANSIBLE_VERSION"
 
 # We install tar here to be able to use the image in Github Action (checkout requires tar)
 RUN zypper refresh \
-    && zypper install -y curl python3 tar
+    && zypper install -y curl python3 tar gzip
 
-RUN curl https://bootstrap.pypa.io/pip/3.6/get-pip.py -o get-pip.py \
-    && python3 get-pip.py \
-    && rm get-pip.py
-
-# install latest 2.10
-RUN python3 -m pip install "ansible==$ANSIBLE_VERSION.*"
+# Install necessary Python version for the controller and use that Python to install Ansible
+COPY build_python.sh /
+ENV ANSIBLE_PYTHON_PATH="/opt/ansible-python"
+RUN zypper install -y gcc automake bzip2 libbz2-devel xz xz-devel openssl-devel \
+    zlib-devel libffi-devel make findutils patch \
+    && bash build_python.sh
+RUN "$ANSIBLE_PYTHON_PATH/bin/python3" -m pip install "ansible==$ANSIBLE_VERSION.*" \
+    # We want the ansible executable to be in $PATH but without interfering with system python
+    && for f in $ANSIBLE_PYTHON_PATH/bin/ansible-*; do ln -s $f "/usr/bin/$(basename $f)"; done


### PR DESCRIPTION
As I discovered while working on https://github.com/DataDog/ansible-datadog/pull/566, we lack tests for newer ansible versions, which relies on the docker images created from this repo. However, Ansible >= 7 requires python >= 3.9 on the controller and Ansible >= 9 requires python >= 3.10 ([reference](https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix) based on ansible-core versions, 2.14 would correspond to Ansible 7, etc.).

Existing images rely on whatever Python is available in the distro's repos, which varies (I've seen py3.9 and py3.8 at least, I think). Installing newer Python requires building it from source, which is what I'm adding here. For now I'm only adding it to a subset of the images sufficient to add some higher ansible version tests; some images may require compiling openssl to get a new enough version to be able to use pip and I don't want to invest so much time now, it can be done later if needed.

Note that this avoids modifying "system python" so that it should still be using the same Python version as before for the "target node".

These images are referenced [here](https://github.com/DataDog/ansible-datadog/blob/main/.circleci/config.yml).