### PR TITLE
Patch systemd centos7 image

### DIFF
--- a/chef-kitchen/systemd/centos7/Dockerfile
+++ b/chef-kitchen/systemd/centos7/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:7
+FROM registry.ddbuild.io/images/base:v38221072-2485f17-centos7
 LABEL maintainer="Agent Platform <team-agent-platform@datadoghq.com>"
 
 RUN yum install -y epel-release


### PR DESCRIPTION
Should fix:
```
       Cannot find a valid baseurl for repo: base/7/x86_64
       Could not retrieve mirrorlist http://mirrorlist.centos.org/?release=7&arch=x86_64&repo=os&infra=container error was
```
Example: https://app.circleci.com/pipelines/github/DataDog/chef-datadog/943/workflows/c55254d6-7576-4a42-83d7-c266bbc03528/jobs/11172