### PR TITLE
Add systemd-enabled CentOS Stream 9 image

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,7 @@ Currently available tags:
 * [`chef_kitchen_systemd_centos_7`](https://github.com/DataDog/docker-library/tree/master/chef-kitchen/systemd/centos7): Chef Kitchen image for testing systemd services on Centos 7
 * [`chef_kitchen_systemd_centos_8`](https://github.com/DataDog/docker-library/tree/master/chef-kitchen/systemd/centos8): Chef Kitchen image for testing systemd services on Centos 8
 * [`chef_kitchen_systemd_centos_9`](https://github.
-  com/DataDog/docker-library/tree/master/chef-kitchen/systemd/centos9): Chef Kitchen image for testing systemd 
-  services on Centos Stream 9
+  com/DataDog/docker-library/tree/master/chef-kitchen/systemd/centos9): Chef Kitchen image for testing systemd services on Centos Stream 9
 * [`chef_kitchen_systemd_opensuse_leap_15`](https://github.com/DataDog/docker-library/tree/master/chef-kitchen/systemd/opensuse): Chef Kitchen image for testing systemd services on OpenSUSE Leap 15
 * [`chef_kitchen_systemd_amazonlinux_2`](https://github.com/DataDog/docker-library/tree/master/chef-kitchen/systemd/amazonlinux2): Chef Kitchen image for testing systemd services on Amazon Linux 2
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ Currently available tags:
 * [`chef_kitchen_systemd_centos_6`](https://github.com/DataDog/docker-library/tree/master/chef-kitchen/systemd/centos6): Chef Kitchen image for testing systemd services on Centos 6
 * [`chef_kitchen_systemd_centos_7`](https://github.com/DataDog/docker-library/tree/master/chef-kitchen/systemd/centos7): Chef Kitchen image for testing systemd services on Centos 7
 * [`chef_kitchen_systemd_centos_8`](https://github.com/DataDog/docker-library/tree/master/chef-kitchen/systemd/centos8): Chef Kitchen image for testing systemd services on Centos 8
+* [`chef_kitchen_systemd_centos_9`](https://github.
+  com/DataDog/docker-library/tree/master/chef-kitchen/systemd/centos9): Chef Kitchen image for testing systemd 
+  services on Centos Stream 9
 * [`chef_kitchen_systemd_opensuse_leap_15`](https://github.com/DataDog/docker-library/tree/master/chef-kitchen/systemd/opensuse): Chef Kitchen image for testing systemd services on OpenSUSE Leap 15
 * [`chef_kitchen_systemd_amazonlinux_2`](https://github.com/DataDog/docker-library/tree/master/chef-kitchen/systemd/amazonlinux2): Chef Kitchen image for testing systemd services on Amazon Linux 2
 

--- a/chef-kitchen/systemd/centos9/Dockerfile
+++ b/chef-kitchen/systemd/centos9/Dockerfile
@@ -1,0 +1,7 @@
+# https://hub.docker.com/r/trfore/docker-centos9-systemd
+# Minimal systemd-enabled CentOS Stream 9 image
+FROM trfore/docker-centos9-systemd:latest
+
+COPY start.sh /root/start.sh
+
+CMD ["/root/start.sh"]

--- a/chef-kitchen/systemd/centos9/Dockerfile
+++ b/chef-kitchen/systemd/centos9/Dockerfile
@@ -1,7 +1,37 @@
-# https://hub.docker.com/r/trfore/docker-centos9-systemd
+# Based on https://hub.docker.com/r/trfore/docker-centos9-systemd
 # Minimal systemd-enabled CentOS Stream 9 image
-FROM trfore/docker-centos9-systemd:latest
+
+FROM quay.io/centos/centos:stream9
+
+ENV container=docker
 
 COPY start.sh /root/start.sh
+
+RUN yum -y update \
+    && yum -y install \
+    epel-release \
+    hostname \
+    initscripts \
+    iproute \
+    openssl \
+    sudo \
+    which \
+    && rm -Rf /usr/share/doc && rm -Rf /usr/share/man \
+    && yum clean all
+
+# selectively remove systemd targets -- See https://hub.docker.com/_/centos/
+RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i == \
+    systemd-tmpfiles-setup.service ] || rm -f $i; done); \
+    rm -f /lib/systemd/system/multi-user.target.wants/*;\
+    rm -f /etc/systemd/system/*.wants/*;\
+    rm -f /lib/systemd/system/local-fs.target.wants/*; \
+    rm -f /lib/systemd/system/sockets.target.wants/*udev*; \
+    rm -f /lib/systemd/system/sockets.target.wants/*initctl*; \
+    rm -f /lib/systemd/system/basic.target.wants/*;\
+    rm -f /lib/systemd/system/anaconda.target.wants/*;
+
+STOPSIGNAL SIGRTMIN+3
+
+VOLUME ["/sys/fs/cgroup"]
 
 CMD ["/root/start.sh"]

--- a/chef-kitchen/systemd/centos9/start.sh
+++ b/chef-kitchen/systemd/centos9/start.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+/usr/sbin/sshd -D -o UseDNS=no -o UsePAM=no -o PasswordAuthentication=yes -o UsePrivilegeSeparation=no -o PidFile=/tmp/sshd.pid &
+
+exec "/sbin/init"


### PR DESCRIPTION
* Add systemd-enabled CentOS Stream 9 image for kitchen tests
* Base image: https://hub.docker.com/r/trfore/docker-centos9-systemd 