### PR TITLE
Update Dockerfile_2022

### DIFF
--- a/sqlserver/windows/Dockerfile_2022
+++ b/sqlserver/windows/Dockerfile_2022
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/windows/servercore:ltsc2019
+FROM mcr.microsoft.com/windows/servercore:ltsc2022
 
 RUN curl "https://go.microsoft.com/fwlink/?LinkID=2215158" -L -o sqlserver-install.exe
 RUN .\sqlserver-install.exe /ACTION="install" /IACCEPTSQLSERVERLICENSETERMS /QUIET /VERBOSE


### PR DESCRIPTION
I think these will need to be bumped to ensure that the version matches the new runner. This was set to 2019 but the 2019 runner has been deprecated